### PR TITLE
keeping auxiliary solutions & subsolutions in enumeration

### DIFF
--- a/src/enum/enumerate.h
+++ b/src/enum/enumerate.h
@@ -30,6 +30,7 @@ class Enumeration
 {
 public:
     static const int DMAX = MaxDimension;
+
     Enumeration(MatGSO<Integer, FT>& gso, Evaluator<FT>& evaluator)
         : _gso(gso), _evaluator(evaluator)
     {
@@ -52,6 +53,8 @@ private:
     enumf centerPartSums[DMAX][DMAX];
     array<enumf, DMAX> rdiag, dist, center, centerPartSum, maxDists, alpha;
     array<enumxt, DMAX> x, dx, ddx, centerLoopBg;
+    array<enumf, DMAX> subsolDists;
+    bool findbettersubsols;
     
     int d, k, kEnd, kMax;
     bool dual;
@@ -78,7 +81,7 @@ private:
 
     void prepareEnumeration(enumf maxDist, const vector<enumxt>& subTree, bool solvingSVP);
   
-    template<bool dualenum>
+    template<bool dualenum, bool dosubsols>
     bool enumerateLoop(enumf& newMaxDist, int& newKMax);
 
     void enumerate(enumf& maxDist, long normExp, const vector<double>& pruning);

--- a/src/svpcvp.h
+++ b/src/svpcvp.h
@@ -32,7 +32,10 @@ int shortestVector(IntMatrix& b, IntVect& solCoord,
         SVPMethod method = SVPM_PROVED, int flags = SVP_DEFAULT);
 
 int shortestVectorPruning(IntMatrix& b, IntVect& solCoord,
-        const vector<double>& pruning, Integer& argIntMaxDist, int flags = SVP_DEFAULT);
+        const vector<double>& pruning, int flags = SVP_DEFAULT);
+
+int shortestVectorPruning(IntMatrix& b, IntVect& solCoord, vector<IntVect>& subsolCoord, vector<double>& subsolDist,
+        const vector<double>& pruning, int flags = SVP_DEFAULT);
 
 // Experimental. Do not use.
 int closestVector(IntMatrix& b, const IntVect& intTarget,


### PR DESCRIPTION
- enumeration,evaluator:
-- added support auxiliary solutions
-- added support subsolutions
- svpcvp:
-- cleaned up a bit (removed radius for shortestVectorEx, unused functions)
-- added support for subsolutions in shortestVectorPruning (currently nowhere used)