### PR TITLE
force instantiation of BKZAutoAbort templates

### DIFF
--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -745,21 +745,27 @@ template <class FT> bool BKZAutoAbort<FT>::test_abort(double scale, int maxNoDec
 */
 
 template class BKZReduction<FP_NR<double> >;
+template class BKZAutoAbort<FP_NR<double> >;
 
 #ifdef FPLLL_WITH_LONG_DOUBLE
 template class BKZReduction<FP_NR<long double> >;
+template class BKZAutoAbort<FP_NR<long double> >;
 #endif
 
 #ifdef FPLLL_WITH_QD
 template class BKZReduction<FP_NR<dd_real> >;
+template class BKZAutoAbort<FP_NR<dd_real> >;
 
 template class BKZReduction<FP_NR<qd_real> >;
+template class BKZAutoAbort<FP_NR<qd_real> >;
 #endif
 
 #ifdef FPLLL_WITH_DPE
 template class BKZReduction<FP_NR<dpe_t> >;
+template class BKZAutoAbort<FP_NR<dpe_t> >;
 #endif
 
 template class BKZReduction<FP_NR<mpfr_t> >;
+template class BKZAutoAbort<FP_NR<mpfr_t> >;
 
 FPLLL_END_NAMESPACE


### PR DESCRIPTION
This fix is required for fpylll