### PR TITLE
fix compiler warning about unitialised values

### DIFF
--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -176,7 +176,7 @@ const Pruning &BKZReduction<FT>::get_pruning(int kappa, int block_size, const BK
   long max_dist_expo;
   FT max_dist = m.getRExp(kappa, kappa, max_dist_expo);
 
-  FT gh_max_dist;
+  FT gh_max_dist = 0.0;
   FT root_det = get_root_det(m, kappa, kappa + block_size);
   compute_gaussian_heuristic(gh_max_dist, max_dist_expo, block_size, root_det, 1.0);
   return strat.get_pruning(max_dist.get_d() * pow(2, max_dist_expo),


### PR DESCRIPTION
bkz.cpp: In member function ‘const fplll::Pruning& fplll::BKZReduction<FT>::get_pruning(int, int, const fplll::BKZParam&) const [with FT = fplll::FP_NR<double>]’:
bkz.cpp:121:3: warning: ‘gh_max_dist.fplll::FP_NR<double>::data’ is used uninitialized in this function [-Wuninitialized]
   if (f < max_dist)
   ^
bkz.cpp:179:6: note: ‘gh_max_dist.fplll::FP_NR<double>::data’ was declared here
   FT gh_max_dist;
      ^