### PR TITLE
add string conversion for FP_NR

### DIFF
--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -68,7 +68,7 @@ template <class FT> double get_current_slope(MatGSO<Integer, FT> &m, int start_r
 template<class FT>
 FT get_root_det(MatGSO<Integer, FT>& m, int start, int end) 
 {
-  FT root_det = 0;
+  FT root_det = 0.0;
   start = max(0, start);
   end = min(m.d, end);
   FT h = (double)(end - start);
@@ -80,7 +80,7 @@ FT get_root_det(MatGSO<Integer, FT>& m, int start, int end)
 template<class FT>
 FT get_log_det(MatGSO<Integer, FT>& m, int start, int end) 
 {
-  FT log_det = 0;
+  FT log_det = 0.0;
   start = max(0, start);
   end = min(m.d, end);
   FT h;
@@ -95,7 +95,7 @@ FT get_log_det(MatGSO<Integer, FT>& m, int start, int end)
 template<class FT>
 FT get_sld_potential(MatGSO<Integer, FT>& m, int start, int end, int block_size)
 {
-  FT potential = 0;
+  FT potential = 0.0;
   int p = (end - start)/block_size;
   if ((end - start) % block_size == 0)
     --p;

--- a/fplll/enum/enumerate.cpp
+++ b/fplll/enum/enumerate.cpp
@@ -187,7 +187,7 @@ template<typename FT>
 void Enumeration<FT>::process_subsolution(int offset, enumf newdist)
 {
     for (int j = 0; j < offset; ++j)
-        fx[j] = 0;
+        fx[j] = 0.0;
     for (int j = offset; j < d; ++j)
         fx[j] = x[j];
     _evaluator.evalSubSol(k, fx, newdist);

--- a/fplll/enum/evaluator.cpp
+++ b/fplll/enum/evaluator.cpp
@@ -238,7 +238,7 @@ void FastEvaluator<Float>::evalSubSol(int offset, const FloatVect& newSubSolCoor
   {
     sub_solCoord[offset] = newSubSolCoord;
     for (int i = 0; i < offset; ++i)
-      sub_solCoord[offset][i] = 0;
+      sub_solCoord[offset][i] = 0.0;
     sub_solDist[offset] = subDist;
   }
 }
@@ -351,7 +351,7 @@ void ExactEvaluator::evalSubSol(int offset, const FloatVect& newSubSolCoord,
   {
     sub_solCoord[offset] = newSubSolCoord;
     for (int i = 0; i < offset; ++i)
-      sub_solCoord[offset][i] = 0;
+      sub_solCoord[offset][i] = 0.0;
     sub_solDist[offset] = subDist;
     sub_solintDist[offset] = newSolDist;
   }

--- a/fplll/enum/evaluator.h
+++ b/fplll/enum/evaluator.h
@@ -131,7 +131,7 @@ public:
     {
       sub_solCoord[offset] = newSubSolCoord;
       for (int i = 0; i < offset; ++i)
-        sub_solCoord[offset][i] = 0;
+        sub_solCoord[offset][i] = 0.0;
       sub_solDist[offset] = subDist;
     }
   }

--- a/fplll/nr/nr_FP.inl
+++ b/fplll/nr/nr_FP.inl
@@ -31,6 +31,7 @@ public:
   inline FP_NR<F>(const FP_NR<F> &f);
   inline ~FP_NR<F>();
   inline FP_NR<F>(const double d) : FP_NR<F>() {*this = d;};
+  inline FP_NR<F>(const char *s) : FP_NR<F>() {*this = s;};
 
   /**
    * Returns the current precision for new FP_NR&lt;F&gt; objects.
@@ -149,6 +150,7 @@ public:
    * Operator
    */
   inline void operator=(const FP_NR<F> &a);
+  inline void operator=(const char *s);
   inline void operator=(double a);
   // inline void operator=(mpfr_t& a);
   inline void operator=(mpfr_t &a) { set_mpfr(a, MPFR_RNDN); };

--- a/fplll/nr/nr_FP_d.inl
+++ b/fplll/nr/nr_FP_d.inl
@@ -5,6 +5,9 @@
 #ifndef FPLLL_NR_FP_D_H
 #define FPLLL_NR_FP_D_H
 
+#include "../defs.h"
+#include "nr_FP.inl"
+
 FPLLL_BEGIN_NAMESPACE
 
 
@@ -100,6 +103,11 @@ inline void FP_NR<double>::operator=(const FP_NR<double>& f) {
 template<>
 inline void FP_NR<double>::operator=(double d) {
   data = d;
+}
+
+template<>
+inline void FP_NR<double>::operator=(const char *s) {
+  data = strtod(s, NULL);
 }
 
 template<>

--- a/fplll/nr/nr_FP_dd.inl
+++ b/fplll/nr/nr_FP_dd.inl
@@ -106,6 +106,11 @@ inline void FP_NR<dd_real>::operator=(double a) {
 }
 
 template<>
+inline void FP_NR<dd_real>::operator=(const char* s) {
+  data.read(s, data);
+}
+
+template<>
 inline bool FP_NR<dd_real>::operator<=(const FP_NR<dd_real>& a) const {
   return data <= a.data;
 }

--- a/fplll/nr/nr_FP_dpe.inl
+++ b/fplll/nr/nr_FP_dpe.inl
@@ -108,6 +108,17 @@ inline void FP_NR<dpe_t>::operator=(double d) {
 }
 
 template<>
+inline void FP_NR<dpe_t>::operator=(const char* s) {
+  DPE_DOUBLE d;
+#ifdef DPE_USE_DOUBLE
+  d = strtod(s, NULL);
+#else
+  d = strtold(s, NULL);
+#endif
+  dpe_set_d(data, d);
+}
+
+template<>
 inline bool FP_NR<dpe_t>::operator<=(const FP_NR<dpe_t>& a) const {
   return dpe_cmp(data, a.data) <= 0;
 }

--- a/fplll/nr/nr_FP_ld.inl
+++ b/fplll/nr/nr_FP_ld.inl
@@ -5,8 +5,10 @@
 #ifndef FPLLL_NR_FP_LD_H
 #define FPLLL_NR_FP_LD_H
 
-FPLLL_BEGIN_NAMESPACE
+#include "../defs.h"
+#include "nr_FP.inl"
 
+FPLLL_BEGIN_NAMESPACE
 
 /* LD specialization if defined */
 #ifdef FPLLL_WITH_LONG_DOUBLE
@@ -104,6 +106,12 @@ template<>
 inline void FP_NR<long double>::operator=(double d) {
   data = d;
 }
+
+template<>
+inline void FP_NR<long double>::operator=(const char *s) {
+  data = strtold(s, NULL);
+}
+
 
 template<>
 inline bool FP_NR<long double>::operator<=(const FP_NR<long double>& a) const {

--- a/fplll/nr/nr_FP_mpfr.inl
+++ b/fplll/nr/nr_FP_mpfr.inl
@@ -107,6 +107,11 @@ inline void FP_NR<mpfr_t>::operator=(double a) {
 }
 
 template<>
+inline void FP_NR<mpfr_t>::operator=(const char *s) {
+  mpfr_set_str(data, s, 10, GMP_RNDN);
+}
+
+template<>
 inline void FP_NR<mpfr_t>::operator=(mpfr_t& a) {
   mpfr_set(data, a, GMP_RNDN);
 }

--- a/fplll/nr/nr_FP_qd.inl
+++ b/fplll/nr/nr_FP_qd.inl
@@ -111,6 +111,11 @@ inline void FP_NR<qd_real>::operator=(double d) {
 }
 
 template<>
+inline void FP_NR<qd_real>::operator=(const char* s) {
+  data.read(s, data);
+}
+
+template<>
 inline bool FP_NR<qd_real>::operator<=(const FP_NR<qd_real>& a) const {
   return data <= a.data;
 }

--- a/fplll/svpcvp.cpp
+++ b/fplll/svpcvp.cpp
@@ -333,7 +333,7 @@ int closestVector(IntMatrix& b, const IntVect& intTarget,
 
   /* Computes a very large bound to make the algorithm work
       until the first solution is found */
-  maxDist = 0;
+  maxDist = 0.0;
   for (int i = 1; i < d; i++) {
     // getRExp(i, i) = r(i, i) because gso is initialized without GSO_ROW_EXPO
     maxDist.add(maxDist, gso.getRExp(i, i));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,9 +11,7 @@ EXTRA_DIST=lattices/dim55_in lattices/example_in lattices/example_svp_in lattice
 AM_CPPFLAGS = -I$(TOPSRCDIR) -I$(TOPBUILDDIR)
 
 STAGEDIR := $(realpath -s $(TOPBUILDDIR)/.libs)
-AM_LDFLAGS = -L$(STAGEDIR) -Wl,-rpath,$(STAGEDIR) -lfplll
-LDFLAGS = -no-install
-LIBADD = $(LIBQD_LIBADD)
+AM_LDFLAGS = -L$(STAGEDIR) -Wl,-rpath,$(STAGEDIR) -lfplll -no-install $(LIBQD_LIBADD)
 
 TESTS = test_lll test_svp test_bkz test_nr
 

--- a/tests/test_nr.cpp
+++ b/tests/test_nr.cpp
@@ -19,6 +19,15 @@
 using namespace std;
 using namespace fplll;
 
+template <class FT> int test_str()
+{
+  int status = 0;
+  FT a = "1.01";
+  status |= !(abs(a - 1.01) < 0.001);
+  return status;
+}
+
+
 template <class FT> int test_arithmetic()
 {
   FT a = 6.0, b = 3.0, c = -2;
@@ -48,18 +57,63 @@ template <class FT> int test_std()
   status |= !(abs(exp(a) - std::exp(a.get_d())) < 0.001);
   status |= !(abs(floor(a) - std::floor(a.get_d())) < 0.001);
   status |= !(abs(pow_si(a, 2) - std::pow(a.get_d(), 2.0)) < 0.001);
-  status |= !(abs(root(a, 3.0) - std::pow(a.get_d(), 1 / 3.0)) < 0.001);
   return status;
 }
+
+template <class FT> int test_root()
+{
+  FT a;
+  a          = 6.1;
+  int status= !(abs(root(a, 3.0) - std::pow(a.get_d(), 1 / 3.0)) < 0.001);
+  return status;
+}
+
+
 
 int main(int argc, char *argv[])
 {
 
   int status = 0;
   status |= test_arithmetic<FP_NR<double>>();
+  status |= test_arithmetic<FP_NR<long double>>();
+#ifdef FPLLL_WITH_DPE
+  status |= test_arithmetic<FP_NR<dpe_t>>();
+#endif
+#ifdef FPLLL_WITH_QD
+  status |= test_arithmetic<FP_NR<dd_real>>();
+  status |= test_arithmetic<FP_NR<qd_real>>();
+#endif
   status |= test_arithmetic<FP_NR<mpfr_t>>();
+
   status |= test_std<FP_NR<double>>();
+  status |= test_std<FP_NR<long double>>();
+#ifdef FPLLL_WITH_DPE
+  status |= test_std<FP_NR<dpe_t>>();
+#endif
+#ifdef FPLLL_WITH_QD
+  status |= test_std<FP_NR<dd_real>>();
+  status |= test_std<FP_NR<qd_real>>();
+#endif
   status |= test_std<FP_NR<mpfr_t>>();
+
+  status |= test_root<FP_NR<double>>();
+  status |= test_root<FP_NR<long double>>();
+#ifdef FPLLL_WITH_QD
+  status |= test_root<FP_NR<dd_real>>();
+  status |= test_root<FP_NR<qd_real>>();
+#endif
+  status |= test_root<FP_NR<mpfr_t>>();
+
+  status |= test_str<FP_NR<double>>();
+  status |= test_str<FP_NR<long double>>();
+#ifdef FPLLL_WITH_DPE
+  status |= test_str<FP_NR<dpe_t>>();
+#endif
+#ifdef FPLLL_WITH_QD
+  status |= test_str<FP_NR<dd_real>>();
+  status |= test_str<FP_NR<qd_real>>();
+#endif
+  status |= test_str<FP_NR<mpfr_t>>();
 
   if (status == 0)
   {

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -144,7 +144,7 @@ template <class ZT> int dual_length(Float &norm, ZZ_mat<ZT> &A, const IntVect &c
 
   FloatVect alpha(d);
   Float mu, alpha2, r_inv;
-  norm = 0;
+  norm = 0.0;
   for (int i = 0; i < d; i++)
   {
     alpha[i] = coords_d[i];


### PR DESCRIPTION
- deal with fallout because 'FP_NR<double> a = 0' now is ambigious
- add tests for new routines
- also extend test coverage of test_nr

fixes #126