### PR TITLE
convention on parameter ordering

### DIFF
--- a/fplll/pruner.cpp
+++ b/fplll/pruner.cpp
@@ -179,7 +179,7 @@ void Pruner<FT>::optimize_coefficients(/*io*/ vector<double> &pr, /*i*/ const in
   }
   else
   {
-    load_coefficients(pr, b);
+    load_coefficients(b, pr);
   }
   descent(b);
   save_coefficients(pr, b);
@@ -187,7 +187,7 @@ void Pruner<FT>::optimize_coefficients(/*io*/ vector<double> &pr, /*i*/ const in
 
 // PRIVATE METHODS
 
-template <class FT> void Pruner<FT>::load_coefficients(/*i*/ const vector<double> &pr, /*o*/ evec &b)
+template <class FT> void Pruner<FT>::load_coefficients(/*o*/ evec &b, /*i*/ const vector<double> &pr)
 {
   for (int i = 0; i < d; ++i)
   {

--- a/fplll/pruner.h
+++ b/fplll/pruner.h
@@ -121,7 +121,7 @@ public:
 
   double single_enum_cost(/*i*/ const vector<double> &pr) {
     evec b;
-    load_coefficients(pr, b);
+    load_coefficients(b, pr);
     return single_enum_cost(b).get_d();
   }
 
@@ -130,7 +130,7 @@ public:
   */
   double repeated_enum_cost(/*i*/ const vector<double> &pr) {
     evec b;
-    load_coefficients(pr, b);
+    load_coefficients(b, pr);
     return repeated_enum_cost(b).get_d();
   }
 
@@ -139,7 +139,7 @@ public:
   */
   double svp_probability(/*i*/ const vector<double> &pr) {
     evec b;
-    load_coefficients(pr, b);
+    load_coefficients(b, pr);
     return svp_probability(b).get_d();
   }
 
@@ -163,7 +163,7 @@ private:
   // Initialize pruning coefficients (linear pruning)
   void init_coefficients(evec &b);
   // Load pruning coefficient from double*
-  void load_coefficients(/*i*/ const vector<double> &pr, /*o*/ evec &b);
+  void load_coefficients(/*o*/ evec &b, /*i*/ const vector<double> &pr);
   // Save pruning coefficients to double*
   void save_coefficients(/*o*/ vector<double> &pr, /*i*/ const evec &b);
   // Enforce reasonable contraints on pruning bounds (inside [0,1], increasing).


### PR DESCRIPTION
typically output params are provided before input params, cf. GMP/MPFR APIs.