### PR TITLE
Pruner interface changes for fpylll

### DIFF
--- a/fplll/pruner.cpp
+++ b/fplll/pruner.cpp
@@ -35,7 +35,7 @@ template <class FT> void Pruner<FT>::set_tabulated_consts()
 
 template <class FT>
 template <class GSO_ZT, class GSO_FT>
-void Pruner<FT>::load_basis_shape(MatGSO<GSO_ZT, GSO_FT> &m, int start_row, int end_row, int reset_renorm)
+void Pruner<FT>::load_basis_shape(MatGSO<GSO_ZT, GSO_FT> &m, int start_row, int end_row, int /*reset_renorm*/)
 {
   if (!end_row)
   {

--- a/fplll/pruner.cpp
+++ b/fplll/pruner.cpp
@@ -90,10 +90,10 @@ template <class FT> void Pruner<FT>::load_basis_shape(const vector<double> &gso_
 }
 
 template <class FT> 
-void Pruner<FT>::load_basis_shapes(const vector<vector<double> > &gso_sq_norms_vec)
+void Pruner<FT>::load_basis_shapes(const vector<vector<double> *> &gso_sq_norms_vec)
 {
   vec sum_ipv;
-  n = gso_sq_norms_vec[0].size();
+  n = (*gso_sq_norms_vec[0]).size();
   for (size_t i = 0; i < n; ++i)
   {
     sum_ipv[i] = 0.;
@@ -101,12 +101,12 @@ void Pruner<FT>::load_basis_shapes(const vector<vector<double> > &gso_sq_norms_v
   int count = gso_sq_norms_vec.size();
   for (int k = 0; k < count; ++k)
   {
-    if (gso_sq_norms_vec[k].size() != n)
+    if ((*gso_sq_norms_vec[k]).size() != n)
     {
       throw std::runtime_error("Inside Pruner : loading several bases with different dimensions");  
     }
     int reset_renorm = (k==0);
-    load_basis_shape(gso_sq_norms_vec[k], reset_renorm);
+    load_basis_shape(*gso_sq_norms_vec[k], reset_renorm);
     for (size_t i = 0; i < n; ++i)
     {
       sum_ipv[i] += ipv[i];
@@ -119,12 +119,12 @@ void Pruner<FT>::load_basis_shapes(const vector<vector<double> > &gso_sq_norms_v
 
 template <class FT> 
 template <class GSO_ZT, class GSO_FT>
-void Pruner<FT>::load_basis_shapes(vector<MatGSO<GSO_ZT, GSO_FT> >&m_vec, int start_row, int end_row)
+void Pruner<FT>::load_basis_shapes(vector<MatGSO<GSO_ZT, GSO_FT> *>&m_vec, int start_row, int end_row)
 {
   vec sum_ipv;
   if (!end_row)
   {
-    end_row = m_vec[0].d;
+    end_row = m_vec[0]->d;
   }
   n = end_row - start_row;
   d = n / 2;
@@ -137,7 +137,7 @@ void Pruner<FT>::load_basis_shapes(vector<MatGSO<GSO_ZT, GSO_FT> >&m_vec, int st
   for (int k = 0; k < count; ++k)
   {
     int reset_renorm = (k==0);    
-    load_basis_shape(m_vec[k], start_row, end_row, reset_renorm);
+    load_basis_shape(*m_vec[k], start_row, end_row, reset_renorm);
     for (size_t i = 0; i < n; ++i)
     {
       sum_ipv[i] += ipv[i];
@@ -441,7 +441,7 @@ template <class FT> void Pruner<FT>::init_coefficients(evec &b)
 template <class FT, class GSO_ZT, class GSO_FT>
 void prune(/*output*/ vector<double> &pr, double &probability,
            /*inputs*/ const double enumeration_radius, const double preproc_cost,
-           const double target_probability, const MatGSO<GSO_ZT, GSO_FT> &m,
+           const double target_probability, MatGSO<GSO_ZT, GSO_FT> &m,
            int start_row, int end_row)
 {
 
@@ -452,11 +452,11 @@ void prune(/*output*/ vector<double> &pr, double &probability,
 }
 
 template <class FT, class GSO_ZT, class GSO_FT>
-void prune(Pruning &pruning,
-           /*inputs*/ const double enumeration_radius, const double preproc_cost,
-           const double target_probability, MatGSO<GSO_ZT, GSO_FT> &m,
-           int start_row, int end_row)
+Pruning prune(/*inputs*/ const double enumeration_radius, const double preproc_cost,
+              const double target_probability, MatGSO<GSO_ZT, GSO_FT> &m,
+              int start_row, int end_row)
 {
+  Pruning pruning;
   if (!end_row)
     end_row = m.d;
   Pruner<FP_NR<double> > pruner(enumeration_radius, preproc_cost, target_probability);
@@ -470,32 +470,81 @@ void prune(Pruning &pruning,
   pruner.optimize_coefficients(pruning.coefficients);
   pruning.probability = pruner.svp_probability(pruning.coefficients);
   pruning.radius_factor = enumeration_radius/(gh_radius.get_d() * pow(2,expo) );
+  return pruning;
 }
+
+
+template <class FT, class GSO_ZT, class GSO_FT>
+Pruning prune(/*inputs*/ const double enumeration_radius, const double preproc_cost,
+              const double target_probability, vector<MatGSO<GSO_ZT, GSO_FT> *> &m,
+              int start_row, int end_row)
+{
+  Pruning pruning;
+  if (!end_row)
+    end_row = m[0]->d;
+  Pruner<FP_NR<double> > pruner(enumeration_radius, preproc_cost, target_probability);
+  pruner.load_basis_shapes(m, start_row, end_row);
+
+
+  FT gh_radius = 0.0;
+  FT root_det = 0.0;
+  for(auto it = m.begin(); it != m.end(); ++it)
+  {
+    FT tmp;
+    (*it)->get_r(tmp, start_row, start_row);
+    gh_radius += tmp;
+    root_det += (*it)->get_root_det(start_row, end_row);
+  }
+  gh_radius /= m.size();
+  root_det /= m.size();
+
+  int expo = 0;
+  gaussian_heuristic(gh_radius, expo, end_row - start_row, root_det, 1.0);
+
+  pruner.optimize_coefficients(pruning.coefficients);
+  pruning.probability = pruner.svp_probability(pruning.coefficients);
+  pruning.radius_factor = enumeration_radius/(gh_radius.get_d() * pow(2,expo) );
+  return pruning;
+}
+
 
 /** instantiate functions **/
 
 template class Pruner<FP_NR<double> >;
-template void prune<FP_NR<double>, Z_NR<mpz_t>, FP_NR<double> > (Pruning&, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<double> >&, int, int);
+template void prune<FP_NR<double>, Z_NR<mpz_t>, FP_NR<double> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<double> >&, int, int);
+template Pruning prune<FP_NR<double>, Z_NR<mpz_t>, FP_NR<double> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<double> >&, int, int);
+template Pruning prune<FP_NR<double>, Z_NR<mpz_t>, FP_NR<double> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<double> >* >&, int, int);
 
 #ifdef FPLLL_WITH_LONG_DOUBLE
 template class Pruner<FP_NR<long double> >;
-template void prune<FP_NR<long double>, Z_NR<mpz_t>, FP_NR<long double> > (Pruning&, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<long double> >&, int, int);
+template void prune<FP_NR<long double>, Z_NR<mpz_t>, FP_NR<long double> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<long double> >&, int, int);
+template Pruning prune<FP_NR<long double>, Z_NR<mpz_t>, FP_NR<long double> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<long double> >&, int, int);
+template Pruning prune<FP_NR<long double>, Z_NR<mpz_t>, FP_NR<long double> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<long double> >* >&, int, int);
+
 #endif
 
 #ifdef FPLLL_WITH_QD
 template class Pruner<FP_NR<dd_real> >;
-template void prune<FP_NR<dd_real>, Z_NR<mpz_t>, FP_NR<dd_real> > (Pruning&, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<dd_real> >&, int, int);;
+template void prune<FP_NR<dd_real>, Z_NR<mpz_t>, FP_NR<dd_real> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<dd_real> >&, int, int);
+template Pruning prune<FP_NR<dd_real>, Z_NR<mpz_t>, FP_NR<dd_real> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<dd_real> >&, int, int);
+template Pruning prune<FP_NR<dd_real>, Z_NR<mpz_t>, FP_NR<dd_real> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<dd_real> >* >&, int, int);
 
 template class Pruner<FP_NR<qd_real> >;
-template void prune<FP_NR<qd_real>, Z_NR<mpz_t>, FP_NR<qd_real> > (Pruning&, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<qd_real> >&, int, int);
+template void prune<FP_NR<qd_real>, Z_NR<mpz_t>, FP_NR<qd_real> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<qd_real> >&, int, int);
+template Pruning prune<FP_NR<qd_real>, Z_NR<mpz_t>, FP_NR<qd_real> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<qd_real> >&, int, int);
+template Pruning prune<FP_NR<qd_real>, Z_NR<mpz_t>, FP_NR<qd_real> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<qd_real> >* >&, int, int);
 #endif
 
 #ifdef FPLLL_WITH_DPE
 template class Pruner<FP_NR<dpe_t> >;
-template void prune<FP_NR<dpe_t>, Z_NR<mpz_t>, FP_NR<dpe_t> > (Pruning&, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t> >&, int, int);
+template void prune<FP_NR<dpe_t>, Z_NR<mpz_t>, FP_NR<dpe_t> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t> >&, int, int);
+template Pruning prune<FP_NR<dpe_t>, Z_NR<mpz_t>, FP_NR<dpe_t> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t> >&, int, int);
+template Pruning prune<FP_NR<dpe_t>, Z_NR<mpz_t>, FP_NR<dpe_t> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t> >* >&, int, int);
 #endif
 
 template class Pruner<FP_NR<mpfr_t> >;
-template void prune<FP_NR<mpfr_t>, Z_NR<mpz_t>, FP_NR<mpfr_t> > (Pruning&, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t> >&, int, int);
+template void prune<FP_NR<mpfr_t>, Z_NR<mpz_t>, FP_NR<mpfr_t> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t> >&, int, int);
+template Pruning prune<FP_NR<mpfr_t>, Z_NR<mpz_t>, FP_NR<mpfr_t> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t> >&, int, int);
+template Pruning prune<FP_NR<mpfr_t>, Z_NR<mpz_t>, FP_NR<mpfr_t> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t> >* >&, int, int);
 
 FPLLL_END_NAMESPACE

--- a/fplll/pruner.cpp
+++ b/fplll/pruner.cpp
@@ -21,26 +21,6 @@
 
 FPLLL_BEGIN_NAMESPACE
 
-template <class FT> Pruner<FT>::Pruner()
-{
-  n = 0;
-  d = 0;
-  set_tabulated_consts();
-
-  epsilon     = std::pow(2., -13);  // Guesswork. Will become obsolete with Nelder-Mead
-  min_step    = std::pow(2., -12);  // Guesswork. Will become obsolete with Nelder-Mead
-  step_factor = std::pow(2, .5);    // Guesswork. Will become obsolete with Nelder-Mead
-  shell_ratio = .995;  // This approximation means that SVP will in fact be approx-SVP with factor
-                       // 1/.995. Sounds fair.
-  min_cf_decrease = .9999;  // We really want the gradient descent to reach the minima
-  symmetry_factor = 2;      // For now, we are just considering SVP
-
-  preproc_cost         = 0.0;  // Please set your own value before running.
-  enumeration_radius   = 0.0;  // Please set your own value before running.
-  target_probability = .90;  // Please set your own value before running.
-  preproc_cost         = 0.0;  // Please set your own value before running.
-}
-
 template <class FT> void Pruner<FT>::set_tabulated_consts()
 {
   for (int i = 0; i < PRUNER_MAX_N; ++i)
@@ -465,14 +445,10 @@ void prune(/*output*/ vector<double> &pr, double &probability,
            int start_row, int end_row)
 {
 
-  Pruner<FP_NR<double>> pru;
-
-  pru.enumeration_radius   = enumeration_radius;
-  pru.target_probability = target_probability;
-  pru.preproc_cost         = preproc_cost;
-  pru.load_basis_shape(m, start_row, end_row);
-  pru.optimize_coefficients(pr);
-  probability = pru.svp_probability(pr);
+  Pruner<FP_NR<double> > pruner(enumeration_radius, preproc_cost, target_probability);
+  pruner.load_basis_shape(m, start_row, end_row);
+  pruner.optimize_coefficients(pr);
+  probability = pruner.svp_probability(pr);
 }
 
 template <class FT, class GSO_ZT, class GSO_FT>
@@ -483,19 +459,16 @@ void prune(Pruning &pruning,
 {
   if (!end_row)
     end_row = m.d;
-  Pruner<FP_NR<double> > pru;
-  pru.enumeration_radius   = enumeration_radius;
-  pru.target_probability = target_probability;
-  pru.preproc_cost         = preproc_cost;
-  pru.load_basis_shape(m, start_row, end_row);
+  Pruner<FP_NR<double> > pruner(enumeration_radius, preproc_cost, target_probability);
+  pruner.load_basis_shape(m, start_row, end_row);
 
   long expo = 0;
   FT gh_radius = m.get_r_exp(start_row, start_row, expo);
   FT root_det = m.get_root_det(start_row, end_row);
   gaussian_heuristic(gh_radius, expo, end_row - start_row, root_det, 1.0);
 
-  pru.optimize_coefficients(pruning.coefficients);
-  pruning.probability = pru.svp_probability(pruning.coefficients);
+  pruner.optimize_coefficients(pruning.coefficients);
+  pruning.probability = pruner.svp_probability(pruning.coefficients);
   pruning.radius_factor = enumeration_radius/(gh_radius.get_d() * pow(2,expo) );
 }
 

--- a/fplll/pruner.cpp
+++ b/fplll/pruner.cpp
@@ -90,10 +90,10 @@ template <class FT> void Pruner<FT>::load_basis_shape(const vector<double> &gso_
 }
 
 template <class FT> 
-void Pruner<FT>::load_basis_shapes(const vector<vector<double> *> &gso_sq_norms_vec)
+void Pruner<FT>::load_basis_shapes(const vector<vector<double>> &gso_sq_norms_vec)
 {
   vec sum_ipv;
-  n = (*gso_sq_norms_vec[0]).size();
+  n = gso_sq_norms_vec[0].size();
   for (size_t i = 0; i < n; ++i)
   {
     sum_ipv[i] = 0.;
@@ -101,12 +101,12 @@ void Pruner<FT>::load_basis_shapes(const vector<vector<double> *> &gso_sq_norms_
   int count = gso_sq_norms_vec.size();
   for (int k = 0; k < count; ++k)
   {
-    if ((*gso_sq_norms_vec[k]).size() != n)
+    if (gso_sq_norms_vec[k].size() != n)
     {
       throw std::runtime_error("Inside Pruner : loading several bases with different dimensions");  
     }
     int reset_renorm = (k==0);
-    load_basis_shape(*gso_sq_norms_vec[k], reset_renorm);
+    load_basis_shape(gso_sq_norms_vec[k], reset_renorm);
     for (size_t i = 0; i < n; ++i)
     {
       sum_ipv[i] += ipv[i];
@@ -119,12 +119,12 @@ void Pruner<FT>::load_basis_shapes(const vector<vector<double> *> &gso_sq_norms_
 
 template <class FT> 
 template <class GSO_ZT, class GSO_FT>
-void Pruner<FT>::load_basis_shapes(vector<MatGSO<GSO_ZT, GSO_FT> *>&m_vec, int start_row, int end_row)
+void Pruner<FT>::load_basis_shapes(vector<MatGSO<GSO_ZT, GSO_FT> >&m_vec, int start_row, int end_row)
 {
   vec sum_ipv;
   if (!end_row)
   {
-    end_row = m_vec[0]->d;
+    end_row = m_vec[0].d;
   }
   n = end_row - start_row;
   d = n / 2;
@@ -137,7 +137,7 @@ void Pruner<FT>::load_basis_shapes(vector<MatGSO<GSO_ZT, GSO_FT> *>&m_vec, int s
   for (int k = 0; k < count; ++k)
   {
     int reset_renorm = (k==0);    
-    load_basis_shape(*m_vec[k], start_row, end_row, reset_renorm);
+    load_basis_shape(m_vec[k], start_row, end_row, reset_renorm);
     for (size_t i = 0; i < n; ++i)
     {
       sum_ipv[i] += ipv[i];
@@ -476,12 +476,12 @@ Pruning prune(/*inputs*/ const double enumeration_radius, const double preproc_c
 
 template <class FT, class GSO_ZT, class GSO_FT>
 Pruning prune(/*inputs*/ const double enumeration_radius, const double preproc_cost,
-              const double target_probability, vector<MatGSO<GSO_ZT, GSO_FT> *> &m,
+              const double target_probability, vector<MatGSO<GSO_ZT, GSO_FT> > &m,
               int start_row, int end_row)
 {
   Pruning pruning;
   if (!end_row)
-    end_row = m[0]->d;
+    end_row = m[0].d;
   Pruner<FP_NR<double> > pruner(enumeration_radius, preproc_cost, target_probability);
   pruner.load_basis_shapes(m, start_row, end_row);
 
@@ -491,9 +491,9 @@ Pruning prune(/*inputs*/ const double enumeration_radius, const double preproc_c
   for(auto it = m.begin(); it != m.end(); ++it)
   {
     FT tmp;
-    (*it)->get_r(tmp, start_row, start_row);
+    it->get_r(tmp, start_row, start_row);
     gh_radius += tmp;
-    root_det += (*it)->get_root_det(start_row, end_row);
+    root_det += it->get_root_det(start_row, end_row);
   }
   gh_radius /= m.size();
   root_det /= m.size();
@@ -513,13 +513,13 @@ Pruning prune(/*inputs*/ const double enumeration_radius, const double preproc_c
 template class Pruner<FP_NR<double> >;
 template void prune<FP_NR<double>, Z_NR<mpz_t>, FP_NR<double> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<double> >&, int, int);
 template Pruning prune<FP_NR<double>, Z_NR<mpz_t>, FP_NR<double> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<double> >&, int, int);
-template Pruning prune<FP_NR<double>, Z_NR<mpz_t>, FP_NR<double> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<double> >* >&, int, int);
+template Pruning prune<FP_NR<double>, Z_NR<mpz_t>, FP_NR<double> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<double> > >&, int, int);
 
 #ifdef FPLLL_WITH_LONG_DOUBLE
 template class Pruner<FP_NR<long double> >;
 template void prune<FP_NR<long double>, Z_NR<mpz_t>, FP_NR<long double> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<long double> >&, int, int);
 template Pruning prune<FP_NR<long double>, Z_NR<mpz_t>, FP_NR<long double> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<long double> >&, int, int);
-template Pruning prune<FP_NR<long double>, Z_NR<mpz_t>, FP_NR<long double> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<long double> >* >&, int, int);
+template Pruning prune<FP_NR<long double>, Z_NR<mpz_t>, FP_NR<long double> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<long double> > >&, int, int);
 
 #endif
 
@@ -527,24 +527,24 @@ template Pruning prune<FP_NR<long double>, Z_NR<mpz_t>, FP_NR<long double> > (co
 template class Pruner<FP_NR<dd_real> >;
 template void prune<FP_NR<dd_real>, Z_NR<mpz_t>, FP_NR<dd_real> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<dd_real> >&, int, int);
 template Pruning prune<FP_NR<dd_real>, Z_NR<mpz_t>, FP_NR<dd_real> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<dd_real> >&, int, int);
-template Pruning prune<FP_NR<dd_real>, Z_NR<mpz_t>, FP_NR<dd_real> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<dd_real> >* >&, int, int);
+template Pruning prune<FP_NR<dd_real>, Z_NR<mpz_t>, FP_NR<dd_real> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<dd_real> > >&, int, int);
 
 template class Pruner<FP_NR<qd_real> >;
 template void prune<FP_NR<qd_real>, Z_NR<mpz_t>, FP_NR<qd_real> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<qd_real> >&, int, int);
 template Pruning prune<FP_NR<qd_real>, Z_NR<mpz_t>, FP_NR<qd_real> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<qd_real> >&, int, int);
-template Pruning prune<FP_NR<qd_real>, Z_NR<mpz_t>, FP_NR<qd_real> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<qd_real> >* >&, int, int);
+template Pruning prune<FP_NR<qd_real>, Z_NR<mpz_t>, FP_NR<qd_real> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<qd_real> > >&, int, int);
 #endif
 
 #ifdef FPLLL_WITH_DPE
 template class Pruner<FP_NR<dpe_t> >;
 template void prune<FP_NR<dpe_t>, Z_NR<mpz_t>, FP_NR<dpe_t> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t> >&, int, int);
 template Pruning prune<FP_NR<dpe_t>, Z_NR<mpz_t>, FP_NR<dpe_t> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t> >&, int, int);
-template Pruning prune<FP_NR<dpe_t>, Z_NR<mpz_t>, FP_NR<dpe_t> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t> >* >&, int, int);
+template Pruning prune<FP_NR<dpe_t>, Z_NR<mpz_t>, FP_NR<dpe_t> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t> > >&, int, int);
 #endif
 
 template class Pruner<FP_NR<mpfr_t> >;
 template void prune<FP_NR<mpfr_t>, Z_NR<mpz_t>, FP_NR<mpfr_t> > (vector<double> &, double &, const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t> >&, int, int);
 template Pruning prune<FP_NR<mpfr_t>, Z_NR<mpz_t>, FP_NR<mpfr_t> > (const double, const double, const double, MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t> >&, int, int);
-template Pruning prune<FP_NR<mpfr_t>, Z_NR<mpz_t>, FP_NR<mpfr_t> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t> >* >&, int, int);
+template Pruning prune<FP_NR<mpfr_t>, Z_NR<mpz_t>, FP_NR<mpfr_t> > (const double, const double, const double, vector<MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t> > >&, int, int);
 
 FPLLL_END_NAMESPACE

--- a/fplll/pruner.h
+++ b/fplll/pruner.h
@@ -267,7 +267,7 @@ Pruning prune(/*inputs*/ const double enumeration_radius, const double preproc_c
 
 template <class FT, class GSO_ZT, class GSO_FT>
 Pruning prune(/*inputs*/ const double enumeration_radius, const double preproc_cost,
-              const double target_probability, vector<MatGSO<GSO_ZT, GSO_FT> *> &m,
+              const double target_probability, vector<MatGSO<GSO_ZT, GSO_FT> > &m,
               int start_row = 0, int end_row = 0);
 
 FPLLL_END_NAMESPACE

--- a/fplll/pruner.h
+++ b/fplll/pruner.h
@@ -110,7 +110,7 @@ public:
       projected sub-lattice [start_row,end_row-1]
   */
   template <class GSO_ZT, class GSO_FT>
-  void load_basis_shapes(vector<MatGSO<GSO_ZT, GSO_FT> *> &gsos, int start_row = 0, int end_row = 0);
+  void load_basis_shapes(vector<MatGSO<GSO_ZT, GSO_FT> > &gsos, int start_row = 0, int end_row = 0);
 
 
   /** @brief load the shape of a basis from vector<double>. Mostly for testing purposes */
@@ -119,7 +119,7 @@ public:
 
   /** @brief load the shapes of may bases from vector<vector<double>> . Cost are average over all bases. Mostly for testing purposes */
 
-  void load_basis_shapes(const vector<vector<double> *> &gso_sq_norms_vec);
+  void load_basis_shapes(const vector<vector<double> > &gso_sq_norms_vec);
 
   /** @brief optimize pruning coefficients
 

--- a/fplll/pruner.h
+++ b/fplll/pruner.h
@@ -67,6 +67,9 @@ public:
   class TestPruner;
   friend class TestPruner;
 
+  /** @brief enumeration radius (squared) */
+  FT enumeration_radius;
+
   /** @brief cost of pre-processing a basis for a retrial
 
       This cost should be expressed in terms of ``nodes'' in an enumeration.
@@ -84,10 +87,20 @@ public:
 
   FT target_probability;
 
-  /** @brief enumeration radius (squared) */
-  FT enumeration_radius;
+  Pruner(FT enumeration_radius=0.0, FT preproc_cost=0.0, FT target_probability=0.9, size_t n=0, size_t d=0):
+    enumeration_radius(enumeration_radius), preproc_cost(preproc_cost), target_probability(target_probability), n(n), d(d)
+  {
+    n = 0;
+    d = 0;
+    set_tabulated_consts();
 
-  Pruner();
+    epsilon     = std::pow(2., -13);  // Guesswork. Will become obsolete with Nelder-Mead
+    min_step    = std::pow(2., -12);  // Guesswork. Will become obsolete with Nelder-Mead
+    step_factor = std::pow(2, .5);    // Guesswork. Will become obsolete with Nelder-Mead
+    shell_ratio = .995;  // This approximation means that SVP will in fact be approx-SVP with factor 1/.995. Sounds fair.
+    min_cf_decrease = .9999;  // We really want the gradient descent to reach the minima
+    symmetry_factor = 2;      // For now, we are just considering SVP
+  }
 
   /** @brief load the shape of a basis from a MatGSO object. Can select a
       projected sub-lattice [start_row,end_row-1]

--- a/fplll/pruner.h
+++ b/fplll/pruner.h
@@ -90,8 +90,6 @@ public:
   Pruner(FT enumeration_radius=0.0, FT preproc_cost=0.0, FT target_probability=0.9, size_t n=0, size_t d=0):
     enumeration_radius(enumeration_radius), preproc_cost(preproc_cost), target_probability(target_probability), n(n), d(d)
   {
-    n = 0;
-    d = 0;
     set_tabulated_consts();
 
     epsilon     = std::pow(2., -13);  // Guesswork. Will become obsolete with Nelder-Mead

--- a/fplll/pruner.h
+++ b/fplll/pruner.h
@@ -112,7 +112,7 @@ public:
       projected sub-lattice [start_row,end_row-1]
   */
   template <class GSO_ZT, class GSO_FT>
-  void load_basis_shapes(vector<MatGSO<GSO_ZT, GSO_FT> > &gsos, int start_row = 0, int end_row = 0);
+  void load_basis_shapes(vector<MatGSO<GSO_ZT, GSO_FT> *> &gsos, int start_row = 0, int end_row = 0);
 
 
   /** @brief load the shape of a basis from vector<double>. Mostly for testing purposes */
@@ -121,7 +121,7 @@ public:
 
   /** @brief load the shapes of may bases from vector<vector<double>> . Cost are average over all bases. Mostly for testing purposes */
 
-  void load_basis_shapes(const vector<vector<double> > &gso_sq_norms_vec);
+  void load_basis_shapes(const vector<vector<double> *> &gso_sq_norms_vec);
 
   /** @brief optimize pruning coefficients
 
@@ -218,40 +218,59 @@ private:
 /**
    @brief prune function, hiding the Pruner class
 
-   @param pr
-   @param probability
-   @param enumeration_radius
-   @param preproc_cost
-   @param target_probability
-   @param m
-   @param start_row
-   @param end_row
+   @param pr store pruning coefficients here
+   @param probability store success probability here
+   @param enumeration_radius target enumeration radius
+   @param preproc_cost cost of preprocessing
+   @param target_probability overall target success probability
+   @param m GSO matrix
+   @param start_row start enumeration here
+   @param end_row stop enumeration here
 */
 
 template <class FT, class GSO_ZT, class GSO_FT>
 void prune(/*output*/ vector<double> &pr, double &probability,
            /*inputs*/ const double enumeration_radius, const double preproc_cost,
-           const double target_probability, const MatGSO<GSO_ZT, GSO_FT> &m,
+           const double target_probability, MatGSO<GSO_ZT, GSO_FT> &m,
            int start_row = 0, int end_row = 0);
 
 /**
    @brief prune function, hiding the Pruner class
 
-   @param pruning
-   @param enumeration_radius
-   @param preproc_cost
-   @param target_probability
-   @param m
-   @param start_row
-   @param end_row
-   @return
+   @param probability store success probability here
+   @param enumeration_radius target enumeration radius
+   @param preproc_cost cost of preprocessing
+   @param target_probability overall target success probability
+   @param m GSO matrix
+   @param start_row start enumeration here
+   @param end_row stop enumeration here
+
+   @return Pruning object.
 */
 
 template <class FT, class GSO_ZT, class GSO_FT>
-void prune(Pruning &pruning,
-           /*inputs*/ const double enumeration_radius, const double preproc_cost,
-           const double target_probability, MatGSO<GSO_ZT, GSO_FT> &m,
-           int start_row = 0, int end_row = 0);
+Pruning prune(/*inputs*/ const double enumeration_radius, const double preproc_cost,
+              const double target_probability, MatGSO<GSO_ZT, GSO_FT> &m,
+              int start_row = 0, int end_row = 0);
+
+/**
+   @brief prune function averaging over several bases
+
+   @param probability store success probability here
+   @param enumeration_radius target enumeration radius
+   @param preproc_cost cost of preprocessing
+   @param target_probability overall target success probability
+   @param m GSO matrices
+   @param start_row start enumeration here
+   @param end_row stop enumeration here
+
+   @return Pruning object.
+*/
+
+template <class FT, class GSO_ZT, class GSO_FT>
+Pruning prune(/*inputs*/ const double enumeration_radius, const double preproc_cost,
+              const double target_probability, vector<MatGSO<GSO_ZT, GSO_FT> *> &m,
+              int start_row = 0, int end_row = 0);
 
 FPLLL_END_NAMESPACE
 

--- a/tests/test_pruner.cpp
+++ b/tests/test_pruner.cpp
@@ -242,20 +242,20 @@ template <class FT> int test_unpruned()
   status |= (abs(1 - proba) > .02);
 
 
-  vector<vector<double> *> gso_sq_norms_vec;
+  vector<vector<double> > gso_sq_norms_vec;
   vector<double> v1,v2,v3;
   v1 = gso_sq_norms;
   v2 = gso_sq_norms;
   v3 = gso_sq_norms;
 
-  gso_sq_norms_vec.emplace_back(&v1);
-  gso_sq_norms_vec.emplace_back(&v2);
+  gso_sq_norms_vec.emplace_back(v1);
+  gso_sq_norms_vec.emplace_back(v2);
   for (int i = 0; i < N; ++i)
   {
     v3[i] *= 20;
   }
 
-  gso_sq_norms_vec.emplace_back(&v3);
+  gso_sq_norms_vec.emplace_back(v3);
   pru.load_basis_shapes(gso_sq_norms_vec);
 
   cerr << "Repeating same checks with 3 bases" << endl;

--- a/tests/test_pruner.cpp
+++ b/tests/test_pruner.cpp
@@ -242,20 +242,20 @@ template <class FT> int test_unpruned()
   status |= (abs(1 - proba) > .02);
 
 
-  vector<vector<double> > gso_sq_norms_vec;
+  vector<vector<double> *> gso_sq_norms_vec;
   vector<double> v1,v2,v3;
   v1 = gso_sq_norms;
   v2 = gso_sq_norms;
   v3 = gso_sq_norms;
 
-  gso_sq_norms_vec.emplace_back(v1);
-  gso_sq_norms_vec.emplace_back(v2);
+  gso_sq_norms_vec.emplace_back(&v1);
+  gso_sq_norms_vec.emplace_back(&v2);
   for (int i = 0; i < N; ++i)
   {
     v3[i] *= 20;
   }
 
-  gso_sq_norms_vec.emplace_back(v3);
+  gso_sq_norms_vec.emplace_back(&v3);
   pru.load_basis_shapes(gso_sq_norms_vec);
 
   cerr << "Repeating same checks with 3 bases" << endl;
@@ -279,10 +279,9 @@ template <class FT> int test_auto_prune(size_t n) {
   MatGSO<Z_NR<mpz_t>, FT> M(A, U, U, GSO_DEFAULT);
   LLLReduction<Z_NR<mpz_t>, FT> lll_obj = LLLReduction<Z_NR<mpz_t>, FT>(M, LLL_DEF_DELTA, LLL_DEF_ETA, LLL_DEFAULT);
   lll_obj.lll();
-  Pruning pruning;
   FT radius;
   M.get_r(radius, 0, 0);
-  prune<FT, Z_NR<mpz_t>, FT >(pruning, radius.get_d(), 10000.0, 0.67, M);
+  Pruning pruning = prune<FT, Z_NR<mpz_t>, FT >(radius.get_d(), 10000.0, 0.67, M);
 
   status |= !(pruning.probability <= 1.0);
   status |= !(pruning.probability > 0.0);


### PR DESCRIPTION
- highlevel `prune` function accepting many bases to average over
- change `vector<vector<double>> gso` to `vector<vector<double>*> gso` and `vector<MatGSO> gso` to `vector<MatGSO*> gso` to avoid copying
- instantiate templates