### PR TITLE
this commit fixes issue #203, building in a subdirectory

### DIFF
--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -6,9 +6,9 @@ AM_CPPFLAGS = -DFPLLL_DEFAULT_STRATEGY_PATH=\"$(strategydir)\" -DFPLLL_DEFAULT_S
 EXTRA_DIST = io/json.hpp ballvol.const factorial.const
 
 nobase_include_fplll_HEADERS=defs.h fplll.h \
-  nr/dpe.h \
-  nr/matrix.h \
-  nr/matrix.cpp \
+	nr/dpe.h \
+	nr/matrix.h \
+	nr/matrix.cpp \
 	nr/nr_FP_dd.inl \
 	nr/nr_FP_d.inl \
 	nr/nr_FP_dpe.inl \

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -21,8 +21,8 @@
 #include <array>
 #include <cfenv>
 #include <cmath>
-#include "../fplll_config.h"
-#include "../nr/nr.h"
+#include "fplll_config.h"
+#include "nr/nr.h"
 
 FPLLL_BEGIN_NAMESPACE
 


### PR DESCRIPTION
Relative paths in the include directives for enumeration_base.h needed
to be fixed. As the respective paths are already included by the
compiler, we do not need to point the preprocessor to the correct
subdirectory.