### PR TITLE
Travis/more tests: macOS and g++-6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,45 +6,23 @@ language: cpp
 
 matrix:
   include:
-  - compiler: gcc
-    env: COMPILER=g++-4.9
+  - os: linux
+    compiler: gcc
+    env: COMPILER=g++-6
     addons:
       apt:
         sources:
         - ubuntu-toolchain-r-test
         packages:
-        - g++-4.9
+        - g++-6
         - libgmp-dev
         - libmpfr-dev
         - libqd-dev
-  - compiler: gcc
-    env: COMPILER=g++-4.8
-    addons:
-      apt:
-        packages:
-        - g++-4.8
-        - libgmp-dev
-        - libmpfr-dev
-        - libqd-dev
-  - compiler: gcc
-    env: COMPILER=g++-5
-    addons:
-      apt:
-        sources:
-        - ubuntu-toolchain-r-test
-        packages:
-        - g++-5
-        - libgmp-dev
-        - libmpfr-dev
-        - libqd-dev
-  - compiler: clang
+  - os: osx
+    compiler: clang
     env: COMPILER=clang++
-    addons:
-      apt:
-        packages:
-        - libgmp-dev
-        - libmpfr-dev
-        - libqd-dev
+    before_install:
+      - brew install gmp mpfr qd autoconf automake libtool 
 
 install:
   - export CXX="$COMPILER"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,40 @@ matrix:
   include:
   - os: linux
     compiler: gcc
+    env: COMPILER=g++-4.8
+    addons:
+      apt:
+        packages:
+        - g++-4.8
+        - libgmp-dev
+        - libmpfr-dev
+        - libqd-dev
+  - os: linux
+    compiler: gcc
+    env: COMPILER=g++-4.9
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-4.9
+        - libgmp-dev
+        - libmpfr-dev
+        - libqd-dev
+  - os: linux
+    compiler: gcc
+    env: COMPILER=g++-5
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-5
+        - libgmp-dev
+        - libmpfr-dev
+        - libqd-dev
+  - os: linux
+    compiler: gcc
     env: COMPILER=g++-6
     addons:
       apt:
@@ -15,6 +49,15 @@ matrix:
         - ubuntu-toolchain-r-test
         packages:
         - g++-6
+        - libgmp-dev
+        - libmpfr-dev
+        - libqd-dev
+  - os: linux
+    compiler: clang
+    env: COMPILER=clang++
+    addons:
+      apt:
+        packages:
         - libgmp-dev
         - libmpfr-dev
         - libqd-dev


### PR DESCRIPTION
Add macOS and g++-6 in Travis matrix. FYI, the test with g++-6 does not catch #218.