### PR TITLE
Handling multiple solutions below a bound

### DIFF
--- a/fplll/enum/evaluator.cpp
+++ b/fplll/enum/evaluator.cpp
@@ -217,13 +217,10 @@ void FastEvaluator<Float>::eval_sol(const FloatVect &new_sol_coord, const enumf 
   {
     if (max_aux_sols != 0 && !sol_coord.empty())
     {
-      aux_sol_coord.emplace_front(std::move(sol_coord));
-      aux_sol_dist.emplace_front(sol_dist);
-      if (aux_sol_coord.size() > max_aux_sols)
+      aux_sols.emplace(sol_dist, sol_coord);
+      if (aux_sols.size() > max_aux_sols)
       {
-        max_dist = aux_sol_dist.back();
-        aux_sol_coord.pop_back();
-        aux_sol_dist.pop_back();
+        max_dist = aux_sols.erase(aux_sols.begin())->first;
       }
     }
     sol_coord = new_sol_coord;
@@ -315,15 +312,13 @@ void ExactEvaluator::eval_sol(const FloatVect &new_sol_coord, const enumf &new_p
     {
       if (max_aux_sols != 0 && !sol_coord.empty())
       {
-        aux_sol_coord.emplace_front(std::move(sol_coord));
-        aux_sol_dist.emplace_front(sol_dist);
-        aux_sol_int_dist.emplace_front(int_max_dist);
-        if (aux_sol_coord.size() > max_aux_sols)
+        aux_sols.emplace(sol_dist, sol_coord);
+        aux_sol_int_dist.emplace(int_max_dist);
+        if (aux_sols.size() > max_aux_sols)
         {
-          max_dist = int_dist2enumf(aux_sol_int_dist.back());
-          aux_sol_coord.pop_back();
-          aux_sol_dist.pop_back();
-          aux_sol_int_dist.pop_back();
+          max_dist = int_dist2enumf(aux_sol_int_dist.top());
+          aux_sols.erase(aux_sols.begin());
+          aux_sol_int_dist.pop();
         }
       }
       // Updates the stored solution

--- a/fplll/enum/evaluator.h
+++ b/fplll/enum/evaluator.h
@@ -202,7 +202,7 @@ public:
   /** Other solutions found in the lattice */
   size_t max_aux_sols;
   bool always_update_rad;
-  std::multimap<enumf, vector<FT>, std::greater<enumf> > aux_sols;
+  std::multimap<enumf, FloatVect, std::greater<enumf> > aux_sols;
 
   /** Subsolutions found in the lattice */
   bool findsubsols;

--- a/fplll/enum/evaluator.h
+++ b/fplll/enum/evaluator.h
@@ -73,12 +73,6 @@ public:
           result.emplace_back(it->first, it->second);
       return result;
   }
-  virtual void set_max_aux_sols(size_t new_max)
-  {
-      FPLLL_CHECK(aux_sols.size() == 0, "invalid call");
-      max_aux_sols = new_max;
-      always_update_rad = always_update_rad||max_aux_sols==0;
-  }
 
   /** Subsolutions found in the lattice */
   bool findsubsols;
@@ -212,13 +206,6 @@ public:
           result.emplace_back(it->first, it->second);
       return result;
   }
-  virtual void set_max_aux_sols(size_t new_max)
-  {
-      FPLLL_CHECK(aux_sols.size() == 0, "invalid call");
-      max_aux_sols = new_max;
-      always_update_rad = always_update_rad||max_aux_sols==0;
-  }
-
 
   // Internal use
   bool get_max_error_aux(const Float &max_dist, bool boundOnExactVal, Float &maxDE);

--- a/fplll/enum/evaluator.h
+++ b/fplll/enum/evaluator.h
@@ -66,6 +66,19 @@ public:
   size_t max_aux_sols;
   bool always_update_rad;
   std::multimap<enumf, vector<FT>, std::greater<enumf> > aux_sols;
+  virtual std::vector<std::pair<enumf, vector<FT> > > multimap2pairs()
+  {
+      std::vector<std::pair<enumf, vector<FT> > > result;
+      for (auto it = aux_sols.rbegin(), itend = aux_sols.rend(); it != itend; ++it)
+          result.emplace_back(it->first, it->second);
+      return result;
+  }
+  virtual void set_max_aux_sols(size_t new_max)
+  {
+      FPLLL_CHECK(aux_sols.size() == 0, "invalid call");
+      max_aux_sols = new_max;
+      always_update_rad = always_update_rad||max_aux_sols==0;
+  }
 
   /** Subsolutions found in the lattice */
   bool findsubsols;
@@ -191,6 +204,21 @@ public:
                         enumf &max_dist) = 0;
   virtual void eval_sub_sol(int offset, const FloatVect &new_sub_sol_coord,
                             const enumf &sub_dist) = 0;
+
+  virtual std::vector<std::pair<enumf, vector<Float> > > multimap2pairs()
+  {
+      std::vector<std::pair<enumf, vector<Float> > > result;
+      for (auto it = aux_sols.rbegin(), itend = aux_sols.rend(); it != itend; ++it)
+          result.emplace_back(it->first, it->second);
+      return result;
+  }
+  virtual void set_max_aux_sols(size_t new_max)
+  {
+      FPLLL_CHECK(aux_sols.size() == 0, "invalid call");
+      max_aux_sols = new_max;
+      always_update_rad = always_update_rad||max_aux_sols==0;
+  }
+
 
   // Internal use
   bool get_max_error_aux(const Float &max_dist, bool boundOnExactVal, Float &maxDE);

--- a/fplll/enum/evaluator.h
+++ b/fplll/enum/evaluator.h
@@ -17,7 +17,8 @@
 #define FPLLL_EVALUATOR_H
 
 #include "../util.h"
-#include <deque>
+#include <map>
+#include <queue>
 
 FPLLL_BEGIN_NAMESPACE
 
@@ -64,8 +65,7 @@ public:
   /** Other solutions found in the lattice */
   size_t max_aux_sols;
   bool always_update_rad;
-  std::deque<vector<FT>> aux_sol_coord;
-  std::deque<enumf> aux_sol_dist;
+  std::multimap<enumf, vector<FT>, std::greater<enumf> > aux_sols;
 
   /** Subsolutions found in the lattice */
   bool findsubsols;
@@ -87,8 +87,7 @@ public:
   using Evaluator<FT>::sol_coord;
   using Evaluator<FT>::sol_dist;
   using Evaluator<FT>::new_sol_flag;
-  using Evaluator<FT>::aux_sol_coord;
-  using Evaluator<FT>::aux_sol_dist;
+  using Evaluator<FT>::aux_sols;
   using Evaluator<FT>::sub_sol_coord;
   using Evaluator<FT>::sub_sol_dist;
   using Evaluator<FT>::max_aux_sols;
@@ -117,13 +116,10 @@ public:
   {
     if (max_aux_sols != 0 && !sol_coord.empty())
     {
-      aux_sol_coord.emplace_front(std::move(sol_coord));
-      aux_sol_dist.emplace_front(sol_dist);
-      if (aux_sol_coord.size() > max_aux_sols)
+      aux_sols.emplace(sol_dist, sol_coord);
+      if (aux_sols.size() > max_aux_sols)
       {
-        max_dist = aux_sol_dist.back();
-        aux_sol_coord.pop_back();
-        aux_sol_dist.pop_back();
+        max_dist = aux_sols.erase(aux_sols.begin())->first;
       }
     }
     sol_coord = new_sol_coord;
@@ -206,8 +202,7 @@ public:
   /** Other solutions found in the lattice */
   size_t max_aux_sols;
   bool always_update_rad;
-  std::deque<FloatVect> aux_sol_coord;
-  std::deque<enumf> aux_sol_dist;
+  std::multimap<enumf, vector<FT>, std::greater<enumf> > aux_sols;
 
   /** Subsolutions found in the lattice */
   bool findsubsols;
@@ -280,7 +275,7 @@ public:
 
   Integer int_max_dist;  // Exact norm of the last vector
 
-  std::deque<Integer> aux_sol_int_dist;  // Exact norm of aux vectors
+  std::priority_queue<Integer> aux_sol_int_dist;  // Exact norm of aux vectors
   vector<Integer> sub_sol_int_dist;      // Exact norm of sub vectors
 
 private:

--- a/fplll/svpcvp.cpp
+++ b/fplll/svpcvp.cpp
@@ -227,15 +227,15 @@ static int shortest_vector_ex(IntMatrix &b, IntVect &sol_coord, SVPMethod method
   {
     auxsol_coord->clear();
     auxsol_dist->clear();
-    auxsol_dist->resize(evaluator->aux_sol_coord.size());
-    for (size_t i = 0; i < evaluator->aux_sol_coord.size(); ++i)
+
+    for (auto it = evaluator->aux_sols.rbegin(), itend = evaluator->aux_sols.rend(); it != itend; ++it)
     {
-      (*auxsol_dist)[i] = evaluator->aux_sol_dist[i];
+      auxsol_dist->push_back(it->first);
 
       IntVect as_c;
-      for (size_t j = 0; j < evaluator->aux_sol_coord[i].size(); ++j)
+      for (size_t j = 0; j < it->second.size(); ++j)
       {
-        itmp1.set_f(evaluator->aux_sol_coord[i][j]);
+        itmp1.set_f(it->second[j]);
         as_c.emplace_back(itmp1);
       }
       auxsol_coord->emplace_back(std::move(as_c));

--- a/fplll/svpcvp.h
+++ b/fplll/svpcvp.h
@@ -38,6 +38,9 @@ int shortest_vector_pruning(IntMatrix &b, IntVect &sol_coord, vector<IntVect> &s
                             vector<double> &subsol_dist, const vector<double> &pruning,
                             int flags = SVP_DEFAULT);
 
+int shortest_vector_pruning(IntMatrix &b, IntVect &sol_coord, vector<IntVect> &auxsol_coord,
+                            vector<double> &auxsol_dist, const int max_aux_sols,
+                            const vector<double> &pruning, int flags = SVP_DEFAULT);
 /**
  * Computes a closest vector of a lattice to a target.
  * The vectors must be linearly independant and the basis must be LLL-reduced


### PR DESCRIPTION
Two things would need to get better:
1) the lengths of the auxiliary solutions are not absolute but relative to the nomExpo and the like. We would need to write something like line 143 of enumerate.cpp to scale back to absolute. I am thinking of the best way to do it.
2) the "SVP" as returned by enumerate is no longer the smallest (when aux solutions are requested) because it is the last enumerated candidate below the bound. So it may not be what we wish...