### PR TITLE
Evaluator recode

### DIFF
--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -278,19 +278,18 @@ bool BKZReduction<FT>::svp_reduction(int kappa, int block_size, const BKZParam &
 
     const Pruning &pruning = get_pruning(kappa, block_size, par);
 
-    vector<FT> &sol_coord = evaluator.sol_coord;
-    sol_coord.clear();
+    evaluator.solutions.clear();
     Enumeration<FT> enum_obj(m, evaluator);
     enum_obj.enumerate(kappa, kappa + block_size, max_dist, max_dist_expo, vector<FT>(),
                        vector<enumxt>(), pruning.coefficients, dual);
     nodes += enum_obj.get_nodes();
 
-    if (!sol_coord.empty())
+    if (!evaluator.empty())
     {
       if (dual)
-        dsvp_postprocessing(kappa, block_size, sol_coord);
+        dsvp_postprocessing(kappa, block_size, evaluator.begin()->second);
       else
-        svp_postprocessing(kappa, block_size, sol_coord);
+        svp_postprocessing(kappa, block_size, evaluator.begin()->second);
 
       rerandomize = false;
     }

--- a/fplll/enum/enumerate.cpp
+++ b/fplll/enum/enumerate.cpp
@@ -37,16 +37,18 @@ template <typename FT> void EnumerationDyn<FT>::reset(enumf cur_dist, int cur_de
   Enumeration<FT> enumobj(_gso, new_evaluator, _max_indices);
   enumobj.enumerate(0, d, new_dist, 0, target, partial_sol, pruning_bounds, false, true);
 
-  if (!new_evaluator.sol_coord.empty())
+  if (!new_evaluator.empty())
   {
-    enumf sol_dist = new_evaluator.sol_dist;
+    FT sol_dist2 = new_evaluator.begin()->first;
+    sol_dist2.mul_2si(sol_dist2, -new_evaluator.normExp);
+    enumf sol_dist = sol_dist2.get_d();
     // FPLLL_TRACE("Recovering sub-solution at level: " << cur_depth <<" soldist: " << sol_dist);
 
     if (sol_dist + cur_dist < partdistbounds[0])
     {
       // FPLLL_TRACE("Saving it.");
       for (int i = 0; i < new_dim; ++i)
-        x[i]     = new_evaluator.sol_coord[i].get_d();
+        x[i]     = new_evaluator.begin()->second[i].get_d();
       process_solution(sol_dist + cur_dist);
     }
   }
@@ -142,8 +144,11 @@ void EnumerationDyn<FT>::enumerate(int first, int last, FT &fmaxdist, long fmaxd
 
   fmaxdist.mul_2si(fmaxdistnorm, dual ? fmaxdistexpo - normexp : normexp - fmaxdistexpo);
 
-  if (dual && !_evaluator.sol_coord.empty())
-    reverse_by_swap(_evaluator.sol_coord, 0, d - 1);
+  if (dual && !_evaluator.empty())
+  {
+    for (auto it = _evaluator.begin(), itend = _evaluator.end(); it != itend; ++it)
+      reverse_by_swap(it->second, 0, d - 1);
+  }
 }
 
 template <typename FT>

--- a/fplll/enum/enumerate_base.cpp
+++ b/fplll/enum/enumerate_base.cpp
@@ -48,6 +48,7 @@ inline void EnumerationBase::enumerate_recursive(
            kk < reset_depth)  // in CVP, below the max GS vector, we reset the partial distance
   {
     reset(newdist, kk);
+    return;
   }
   else
   {
@@ -93,11 +94,6 @@ inline void EnumerationBase::enumerate_recursive(
         if (newdist2 > 0.0 || !is_svp)
           process_solution(newdist2);
       }
-      else if (enable_reset &&
-               kk < reset_depth)  // in CVP, below the max GS vector, we reset the partial distance
-      {
-        reset(newdist, kk);
-      }
       else
       {
         partdist[kk - 1] = newdist2;
@@ -128,11 +124,6 @@ inline void EnumerationBase::enumerate_recursive(
       {
         if (newdist2 > 0.0 || !is_svp)
           process_solution(newdist2);
-      }
-      else if (enable_reset &&
-               kk < reset_depth)  // in CVP, below the max GS vector, we reset the partial distance
-      {
-        reset(newdist, kk);
       }
       else
       {

--- a/fplll/enum/evaluator.cpp
+++ b/fplll/enum/evaluator.cpp
@@ -355,7 +355,7 @@ Float ExactErrorBoundedEvaluator::int_dist2Float(Integer int_dist)
   FPLLL_CHECK(result, "ExactEvaluator: error cannot be bounded");
   FPLLL_CHECK(maxDE <= r(0, 0), "ExactEvaluator: max error is too large");
   fMaxDist.add(fMaxDist, maxDE);
-  fMaxDist.mul_2si(fMaxDist, -normExp);
+  //  fMaxDist.mul_2si(fMaxDist, -normExp);
   return fMaxDist;
 }
 

--- a/fplll/latticegen.cpp
+++ b/fplll/latticegen.cpp
@@ -217,7 +217,7 @@ int main(int argc, char *argv[])
   }
   case 'T':
   {
-    FP_NR<mpfr_t> *w = new FP_NR<mpfr_t>[ d ];
+    FP_NR<mpfr_t> *w = new FP_NR<mpfr_t>[d];
 
     for (int i = 0; i < d; i++)
       mpfr_inp_str(w[i].get_data(), stdin, 10, GMP_RNDN);

--- a/fplll/nr/matrix.cpp
+++ b/fplll/nr/matrix.cpp
@@ -275,7 +275,7 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_ntrulike(int bits)
     FPLLL_ABORT("gen_ntrulike called on an ill-formed matrix");
     return;
   }
-  Z_NR<ZT> *h = new Z_NR<ZT>[ d ];
+  Z_NR<ZT> *h = new Z_NR<ZT>[d];
   Z_NR<ZT> q;
 
   q.randb(bits);
@@ -343,7 +343,7 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_ntrulike_withq(int q)
     FPLLL_ABORT("gen_ntrulike called on an ill-formed matrix");
     return;
   }
-  Z_NR<ZT> *h = new Z_NR<ZT>[ d ];
+  Z_NR<ZT> *h = new Z_NR<ZT>[d];
   Z_NR<ZT> q2;
 
   q2   = q;
@@ -407,7 +407,7 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_ntrulike2(int bits)
     FPLLL_ABORT("gen_ntrulike2 called on an ill-formed matrix");
     return;
   }
-  Z_NR<ZT> *h = new Z_NR<ZT>[ d ];
+  Z_NR<ZT> *h = new Z_NR<ZT>[d];
   Z_NR<ZT> q;
 
   q.randb(bits);
@@ -461,7 +461,7 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_ntrulike2_withq(int q)
     FPLLL_ABORT("gen_ntrulike2 called on an ill-formed matrix");
     return;
   }
-  Z_NR<ZT> *h = new Z_NR<ZT>[ d ];
+  Z_NR<ZT> *h = new Z_NR<ZT>[d];
   Z_NR<ZT> q2;
 
   q2   = q;

--- a/fplll/nr/nr_FP.inl
+++ b/fplll/nr/nr_FP.inl
@@ -154,6 +154,12 @@ public:
   inline void operator=(double a);
   // inline void operator=(mpfr_t& a);
   inline void operator=(mpfr_t &a) { set_mpfr(a, MPFR_RNDN); };
+
+  inline bool operator==(const FP_NR<F> &a) const { return cmp(a) == 0; }
+  inline bool operator==(double a) const { return cmp(a) == 0; }
+  inline bool operator!=(const FP_NR<F> &a) const { return cmp(a) != 0; }
+  inline bool operator!=(double a) const { return cmp(a) != 0; }
+
   inline bool operator<(const FP_NR<F> &a) const;
   inline bool operator<(double a) const;
   inline bool operator>(const FP_NR<F> &a) const;


### PR DESCRIPTION
* Evaluator classes reshaped:
  Evaluator<FT>
   \- FastEvaluator<FT>: Evaluator<FT>
   \- ErrorBoundedEvaluator: Evaluator<Float>
      \- FastErrorBoundedEvaluator: ErrorBoundedEvaluator
      \- ExactErrorBoundedEvaluator: ExactErrorBoundedEvaluator

* Previously FastEvaluator<Float> had extra behaviour compared to FastEvaluator<FT>
  this has now been moved into ErrorBoundedEvaluator for greater clearity

* Instead of auxsolutions (i.e., a shortest vector and a vector of other short vectors)
  Evaluator stores all its solutions in a multimap (ordered from longest to shortest),
  and updates this multimap and the enumeration bound according to a given EvaluatorStrategy:
  * EVALSTRATEGY_BEST_N_SOLUTIONS:
    Keep up to N=<nr_solutions> sols, adjust enumeration bound only on the N-th shortest solution.
    Since the enumeration bound is adjusted only after N solutions, for N>1 this increases the cost.

  * EVALSTRATEGY_OPPORTUNISTIC_N_SOLUTIONS:
    Keep up to N=<nr_solutions> sols, adjust enumeration bound on the shortest solution.
    You get N solutions for the price of the shortest one, but these are not guaranteed to be the N shortest solutions.

  * EVALSTRATEGY_FIRST_N_SOLUTIONS:
    When N solutions have been found, set enumeration bound to 0.
    This is an early abort strategy.

* Bugfix for reset behaviour in enumerate_base.cpp