### PR TITLE
Added support for external enumeration libraries.

### DIFF
--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -30,7 +30,7 @@ nobase_include_fplll_HEADERS=defs.h fplll.h \
 	enum/evaluator.h \
 	fplll_config.h wrapper.h \
 	bkz_param.h \
-	enum/enumerate.h enum/enumerate_base.h \
+	enum/enumerate.h enum/enumerate_base.h enum/enumerate_ext.h \
 	pruner.h
 
 bin_PROGRAMS=fplll latticegen latsieve
@@ -69,6 +69,7 @@ libfplll_la_SOURCES=fplll.cpp fplll.h \
 	enum/topenum.cpp enum/topenum.h \
 	enum/enumerate.cpp enum/enumerate.h \
 	enum/enumerate_base.cpp enum/enumerate_base.h \
+	enum/enumerate_ext.cpp enum/enumerate_ext.h \
 	enum/evaluator.cpp enum/evaluator.h \
 	lll.cpp lll.h \
 	wrapper.cpp wrapper.h \

--- a/fplll/enum/enumerate.h
+++ b/fplll/enum/enumerate.h
@@ -65,13 +65,11 @@ private:
   virtual void process_subsolution(int offset, enumf newdist);
 };
 
-
-
 template <typename FT> class Enumeration
 {
 public:
   Enumeration(MatGSO<Integer, FT> &gso, Evaluator<FT> &evaluator,
-              const vector<int>& max_indices = vector<int>())
+              const vector<int> &max_indices = vector<int>())
       : _gso(gso), _evaluator(evaluator), _max_indices(max_indices), enumdyn(nullptr)
   {
   }
@@ -93,7 +91,8 @@ public:
         return;
       }
     }
-    // if external enumerator is not available, not possible or when it fails then fall through to fplll enumeration
+    // if external enumerator is not available, not possible or when it fails then fall through to
+    // fplll enumeration
     if (enumdyn.get() == nullptr)
       enumdyn.reset(new EnumerationDyn<FT>(_gso, _evaluator, _max_indices));
     enumdyn->enumerate(first, last, fmaxdist, fmaxdistexpo, target_coord, subtree, pruning, dual,
@@ -104,7 +103,7 @@ public:
   inline uint64_t get_nodes() const { return _nodes; }
 
 private:
-  MatGSO<Integer, FT> &_gso; 
+  MatGSO<Integer, FT> &_gso;
   Evaluator<FT> &_evaluator;
   vector<int> _max_indices;
   std::unique_ptr<EnumerationDyn<FT>> enumdyn;

--- a/fplll/enum/enumerate.h
+++ b/fplll/enum/enumerate.h
@@ -21,6 +21,7 @@
 
 #include <array>
 #include <fplll/enum/enumerate_base.h>
+#include <fplll/enum/enumerate_ext.h>
 #include <fplll/enum/evaluator.h>
 #include <fplll/gso.h>
 #include <memory>
@@ -64,12 +65,14 @@ private:
   virtual void process_subsolution(int offset, enumf newdist);
 };
 
+
+
 template <typename FT> class Enumeration
 {
 public:
   Enumeration(MatGSO<Integer, FT> &gso, Evaluator<FT> &evaluator,
-              vector<int> max_indices = vector<int>())
-      : enumdyn(new EnumerationDyn<FT>(gso, evaluator, max_indices))
+              const vector<int>& max_indices = vector<int>())
+      : _gso(gso), _evaluator(evaluator), _max_indices(max_indices), enumdyn(nullptr)
   {
   }
 
@@ -79,14 +82,34 @@ public:
                  const vector<enumf> &pruning = vector<enumf>(), bool dual = false,
                  bool subtree_reset = false)
   {
+    // check for external enumerator and use that
+    if (get_external_enumerator() != nullptr && subtree.empty() && target_coord.empty())
+    {
+      if (enumext.get() == nullptr)
+        enumext.reset(new ExternalEnumeration<FT>(_gso, _evaluator));
+      if (enumext->enumerate(first, last, fmaxdist, fmaxdistexpo, pruning, dual))
+      {
+        _nodes = enumext->get_nodes();
+        return;
+      }
+    }
+    // if external enumerator is not available, not possible or when it fails then fall through to fplll enumeration
+    if (enumdyn.get() == nullptr)
+      enumdyn.reset(new EnumerationDyn<FT>(_gso, _evaluator, _max_indices));
     enumdyn->enumerate(first, last, fmaxdist, fmaxdistexpo, target_coord, subtree, pruning, dual,
                        subtree_reset);
+    _nodes = enumdyn->get_nodes();
   }
 
-  inline uint64_t get_nodes() const { return enumdyn->get_nodes(); }
+  inline uint64_t get_nodes() const { return _nodes; }
 
 private:
+  MatGSO<Integer, FT> &_gso; 
+  Evaluator<FT> &_evaluator;
+  vector<int> _max_indices;
   std::unique_ptr<EnumerationDyn<FT>> enumdyn;
+  std::unique_ptr<ExternalEnumeration<FT>> enumext;
+  uint64_t _nodes;
 };
 
 FPLLL_END_NAMESPACE

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -28,8 +28,8 @@
 
 FPLLL_BEGIN_NAMESPACE
 
-inline void roundto(int &dest, const double &src) { dest = std::lrint(src); }
-inline void roundto(double &dest, const double &src) { dest = std::rint(src); }
+inline void roundto(int &dest, const double &src) { dest = (int)round(src); }
+inline void roundto(double &dest, const double &src) { dest = round(src); }
 
 /* config */
 #define FPLLL_WITH_RECURSIVE_ENUM 1

--- a/fplll/enum/enumerate_ext.cpp
+++ b/fplll/enum/enumerate_ext.cpp
@@ -58,12 +58,14 @@ bool ExternalEnumeration<FT>::enumerate(int first, int last, FT &fmaxdist, long 
   _maxdist = fmaxdistnorm.get_d(GMP_RNDU);
   _evaluator.set_normexp(_normexp);
 
-  _nodes = fplll_extenum(
-      _maxdist, std::bind(&ExternalEnumeration<FT>::callback_set_config, this, _1, _2, _3, _4, _5),
-      std::bind(&ExternalEnumeration<FT>::callback_process_sol, this, _1, _2),
-      std::bind(&ExternalEnumeration<FT>::callback_process_subsol, this, _1, _2, _3), _dual,
-      _evaluator.findsubsols);
-
+  // clang-format off
+  _nodes = fplll_extenum(_d, _maxdist,
+               std::bind(&ExternalEnumeration<FT>::callback_set_config, this, _1, _2, _3, _4, _5),
+               std::bind(&ExternalEnumeration<FT>::callback_process_sol, this, _1, _2),
+               std::bind(&ExternalEnumeration<FT>::callback_process_subsol, this, _1, _2, _3),
+               _dual, _evaluator.findsubsols
+               );
+  // clang-format on
   return _nodes != ~uint64_t(0);
 }
 

--- a/fplll/enum/enumerate_ext.cpp
+++ b/fplll/enum/enumerate_ext.cpp
@@ -69,7 +69,6 @@ bool ExternalEnumeration<FT>::enumerate(int first, int last, FT &fmaxdist, long 
   return _nodes != ~uint64_t(0);
 }
 
-
 template <typename FT>
 void ExternalEnumeration<FT>::callback_set_config(enumf *mu, size_t mudim, bool mutranspose,
                                                   enumf *rdiag, enumf *pruning)

--- a/fplll/enum/enumerate_ext.cpp
+++ b/fplll/enum/enumerate_ext.cpp
@@ -53,7 +53,7 @@ bool ExternalEnumeration<FT>::enumerate(int first, int last, FT &fmaxdist, long 
     fr       = _gso.get_r_exp(i + first, i + first, rexpo);
     _normexp = max(_normexp, rexpo + fr.exponent());
   }
-  fmaxdistnorm.mul_2si(fmaxdist, fmaxdistexpo - _normexp);
+  fmaxdistnorm.mul_2si(fmaxdist, dual ? _normexp - fmaxdistexpo : fmaxdistexpo - _normexp);
 
   _maxdist = fmaxdistnorm.get_d(GMP_RNDU);
   _evaluator.set_normexp(_normexp);
@@ -68,6 +68,7 @@ bool ExternalEnumeration<FT>::enumerate(int first, int last, FT &fmaxdist, long 
   // clang-format on
   return _nodes != ~uint64_t(0);
 }
+
 
 template <typename FT>
 void ExternalEnumeration<FT>::callback_set_config(enumf *mu, size_t mudim, bool mutranspose,
@@ -88,10 +89,11 @@ void ExternalEnumeration<FT>::callback_set_config(enumf *mu, size_t mudim, bool 
     size_t offs = 0;
     for (int i = 0; i < _d; ++i, offs += mudim)
     {
-      for (int j = i + 1; j < _d; ++j)
+      for (int j = 0; j < _d; ++j)
       {
         _gso.get_mu(fmu, j + _first, i + _first);
-        /* mu[i][j]= */ mu[offs + j] = fmu.get_d();
+        /* mu[i][j]= */
+        mu[offs + j] = fmu.get_d();
       }
     }
   }
@@ -100,10 +102,11 @@ void ExternalEnumeration<FT>::callback_set_config(enumf *mu, size_t mudim, bool 
     size_t offs = 0;
     for (int j = 0; j < _d; ++j, offs += mudim)
     {
-      for (int i = 0; i < j; ++i)
+      for (int i = 0; i < _d; ++i)
       {
         _gso.get_mu(fmu, j + _first, i + _first);
-        /* mu[j][i] = */ mu[offs + i] = fmu.get_d();
+        /* mu[j][i] = */
+        mu[offs + i] = fmu.get_d();
       }
     }
   }

--- a/fplll/enum/enumerate_ext.cpp
+++ b/fplll/enum/enumerate_ext.cpp
@@ -1,0 +1,166 @@
+/* 
+   (C) 2016 Marc Stevens. 
+
+   This file is part of fplll. fplll is free software: you
+   can redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License as published by the Free Software Foundation,
+   either version 2.1 of the License, or (at your option) any later version.
+
+   fplll is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with fplll. If not, see <http://www.gnu.org/licenses/>. */
+
+#include "enumerate_ext.h"
+
+FPLLL_BEGIN_NAMESPACE
+
+// set & get external enumerator (nullptr => disabled)
+std::function<extenum_fc_enumerate> fplll_extenum = nullptr;
+void set_external_enumerator(std::function<extenum_fc_enumerate> extenum)
+{
+  fplll_extenum = extenum;
+}
+std::function<extenum_fc_enumerate> get_external_enumerator()
+{
+  return fplll_extenum;
+}
+
+template<typename FT> 
+bool ExternalEnumeration<FT>::enumerate(int first, int last, FT &fmaxdist, long fmaxdistexpo,
+                                    const vector<enumf> &pruning, bool dual)
+{
+  using namespace std::placeholders;
+  if (fplll_extenum == nullptr)
+    return false;
+  if (last == -1)
+    last = _gso.d;
+    
+  _first = first;
+  _dual = dual;
+  _pruning = pruning;
+  _d = last - _first;
+  _fx.resize(_d);
+  
+  FPLLL_CHECK(_pruning.empty() || _pruning.size() >= _d, "ExternalEnumeration: non-empty pruning vector too small");
+  
+  FT fr, fmu, fmaxdistnorm;
+  long rexpo;
+  _normexp = -1;
+  for (int i = 0; i < _d; ++i)
+  {
+    fr = _gso.get_r_exp(i + first, i + first, rexpo);
+    _normexp = max(_normexp, rexpo + fr.exponent());
+  }
+  fmaxdistnorm.mul_2si(fmaxdist, fmaxdistexpo - _normexp);
+
+  _maxdist = fmaxdistnorm.get_d(GMP_RNDU);
+  _evaluator.set_normexp(_normexp);
+
+  _nodes = fplll_extenum(_maxdist, 
+                         std::bind(&ExternalEnumeration<FT>::callback_set_config, this, _1, _2, _3, _4, _5),
+                         std::bind(&ExternalEnumeration<FT>::callback_process_sol, this, _1, _2),
+                         std::bind(&ExternalEnumeration<FT>::callback_process_subsol, this, _1, _2, _3),
+                         _dual,
+                         _evaluator.findsubsols
+                         );
+                           
+  return _nodes != -1ULL;
+}
+
+template<typename FT> 
+void ExternalEnumeration<FT>::callback_set_config(
+     enumf* mu, size_t mudim, bool mutranspose, 
+     enumf* rdiag,
+     enumf* pruning)
+{
+  FT fr, fmu;
+  long rexpo;
+  
+  for (int i = 0; i < _d; ++i)
+  {
+    fr = _gso.get_r_exp(i + _first, i + _first, rexpo);
+    fr.mul_2si(fr, rexpo - _normexp);
+    rdiag[i] = fr.get_d(); 
+  }
+  
+  if (mutranspose)
+  {
+    size_t offs = 0;
+    for (int i = 0; i < _d; ++i, offs += mudim)
+    {
+      for (int j = i + 1; j < _d; ++j)
+      {
+        _gso.get_mu(fmu, j + _first, i + _first);
+        /* mu[i][j]= */ mu[offs + j] = fmu.get_d();
+      }
+    }
+  } 
+  else 
+  {
+    size_t offs = 0;
+    for (int j = 0; j < _d; ++j, offs += mudim)
+    {
+      for (int i = 0; i < j; ++i)
+      {
+        _gso.get_mu(fmu, j + _first, i + _first);
+        /* mu[j][i] = */ mu[offs + i] = fmu.get_d();
+      }
+    }
+  }
+  
+  if (_pruning.empty())
+  {
+    for (int i = 0; i < _d; ++i)
+      pruning[i] = 1.0;
+  }
+  else
+  {
+    for (int i = 0; i < _d; ++i)
+      pruning[i] = _pruning[i];
+  }  
+  
+}
+
+template<typename FT> 
+enumf ExternalEnumeration<FT>::callback_process_sol(enumf dist, enumf* sol)
+{
+  for (int i = 0; i < _d; ++i)
+    _fx[i] = sol[i];
+  _evaluator.eval_sol(_fx, dist, _maxdist);  
+  return _maxdist;
+}
+
+template<typename FT> 
+void ExternalEnumeration<FT>::callback_process_subsol(enumf dist, enumf* subsol, int offset)
+{
+  for (int i = 0; i < offset; ++i)
+    _fx[i] = 0.0;
+  for (int i = offset; i < _d; ++i)
+    _fx[i] = subsol[i];
+  _evaluator.eval_sub_sol(offset, _fx, dist);
+}
+
+template class ExternalEnumeration<FP_NR<double>>;
+
+#ifdef FPLLL_WITH_LONG_DOUBLE
+template class ExternalEnumeration<FP_NR<long double>>;
+#endif
+
+#ifdef FPLLL_WITH_QD
+template class ExternalEnumeration<FP_NR<dd_real>>;
+
+template class ExternalEnumeration<FP_NR<qd_real>>;
+#endif
+
+#ifdef FPLLL_WITH_DPE
+template class ExternalEnumeration<FP_NR<dpe_t>>;
+#endif
+
+template class ExternalEnumeration<FP_NR<mpfr_t>>;
+
+FPLLL_END_NAMESPACE
+

--- a/fplll/enum/enumerate_ext.cpp
+++ b/fplll/enum/enumerate_ext.cpp
@@ -64,7 +64,7 @@ bool ExternalEnumeration<FT>::enumerate(int first, int last, FT &fmaxdist, long 
       std::bind(&ExternalEnumeration<FT>::callback_process_subsol, this, _1, _2, _3), _dual,
       _evaluator.findsubsols);
 
-  return _nodes != -1ULL;
+  return _nodes != ~uint64_t(0);
 }
 
 template <typename FT>

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -28,22 +28,47 @@ FPLLL_BEGIN_NAMESPACE
 
 /* function callback API for external enumeration library (extenum) */
 
-// prototype: function to give to extenum who can call it to fill mu and rdiag
-//    assumes mu is defined as: enumf mu[mudim][mudim];
-//    if transpose==true then will transpose mu
+/**
+ * Callback function given to external enumeration library.
+ *
+ * You have to pass a pointer to an array 'enumf mu[mudim][mudim]'.
+ * When flag mutranspose is true then mutransposed is actually stored there.
+ * You have to pass a pointer to an array 'enumf rdiag[mudim]'
+ * and an array 'enumf pruning[mudim]'.
+ * Note: for dual SVP you also get mu and rdiag as is,
+ * so the external library must make the respective changes to Mu and Rdiag itself.
+ */
 typedef void(extenum_cb_set_config)(enumf *mu, size_t mudim, bool mutranspose, enumf *rdiag,
                                     enumf *pruning);
 
-// prototype: function to give to extenum who can call it when it finds a solution
-//    returns new enumeration bound
+/**
+ * Callback function given to external enumeration library.
+ *
+ * Pass a new solution and its length to Evaluator, it returns the new enumeration bound.
+ */
 typedef enumf(extenum_cb_process_sol)(enumf dist, enumf *sol);
 
-// prototype: function to give to extenum who can call it when it finds a subsolution
-//    returns new enumeration bound
+/**
+ * Callback function given to external enumeration library.
+ *
+ * Pass a subsolution and its partial length to Evaluator.
+ */
 typedef void(extenum_cb_process_subsol)(enumf dist, enumf *subsol, int offset);
 
-// prototype: extenum function
-//    return node count or ~uint64_t(0) when it fails
+/**
+ * External enumeration function prototype.
+ *
+ * @param dim         enumeration dimension
+ * @param cbfunc      given callback function to get mu, rdiag, pruning
+ * @param cbsol       given callback function to pass solution and its length to Evaluator,
+ *                    it returns new enumeration bound
+ * @param cbsubsol    given callback function to pass subsolution and its length to Evaluator
+ * @param dual        do dual SVP enumeration
+ * @param findsubsols find subsolutions and pass them to Evaluator
+ * @return number of nodes visited.
+ *         Or ~uint64_t(0) when instance is not supported
+ *         in which case fplll falls back to its own enumeration.
+ */
 typedef uint64_t(extenum_fc_enumerate)(int dim, enumf maxdist,
                                        std::function<extenum_cb_set_config> cbfunc,
                                        std::function<extenum_cb_process_sol> cbsol,

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -43,7 +43,7 @@ typedef enumf(extenum_cb_process_sol)(enumf dist, enumf *sol);
 typedef void(extenum_cb_process_subsol)(enumf dist, enumf *subsol, int offset);
 
 // prototype: extenum function
-//    return node count or -1ULL == ~uint64_t(0) when it fails
+//    return node count or ~uint64_t(0) when it fails
 typedef uint64_t(extenum_fc_enumerate)(enumf maxdist, std::function<extenum_cb_set_config> cbfunc,
                                        std::function<extenum_cb_process_sol> cbsol,
                                        std::function<extenum_cb_process_subsol> cbsubsol,

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -1,5 +1,5 @@
-/* 
-   (C) 2016 Marc Stevens. 
+/*
+   (C) 2016 Marc Stevens.
 
    This file is part of fplll. fplll is free software: you
    can redistribute it and/or modify it under the terms of the GNU Lesser
@@ -21,8 +21,8 @@
 #include <fplll/enum/enumerate_base.h>
 #include <fplll/enum/evaluator.h>
 #include <fplll/gso.h>
-#include <memory>
 #include <functional>
+#include <memory>
 
 FPLLL_BEGIN_NAMESPACE
 
@@ -31,60 +31,48 @@ FPLLL_BEGIN_NAMESPACE
 // prototype: function to give to extenum who can call it to fill mu and rdiag
 //    assumes mu is defined as: enumf mu[mudim][mudim];
 //    if transpose==true then will transpose mu
-typedef void (extenum_cb_set_config)(
-    enumf* mu, size_t mudim, bool mutranspose, 
-    enumf* rdiag,
-    enumf* pruning
-    ); 
+typedef void(extenum_cb_set_config)(enumf *mu, size_t mudim, bool mutranspose, enumf *rdiag,
+                                    enumf *pruning);
 
 // prototype: function to give to extenum who can call it when it finds a solution
 //    returns new enumeration bound
-typedef enumf (extenum_cb_process_sol)(enumf dist, enumf* sol);
+typedef enumf(extenum_cb_process_sol)(enumf dist, enumf *sol);
 
 // prototype: function to give to extenum who can call it when it finds a subsolution
 //    returns new enumeration bound
-typedef void (extenum_cb_process_subsol)(enumf dist, enumf* subsol, int offset);
- 
+typedef void(extenum_cb_process_subsol)(enumf dist, enumf *subsol, int offset);
+
 // prototype: extenum function
 //    return node count or -1ULL == ~uint64_t(0) when it fails
-typedef uint64_t (extenum_fc_enumerate)(
-    enumf maxdist,
-    std::function<extenum_cb_set_config> cbfunc, 
-    std::function<extenum_cb_process_sol> cbsol, 
-    std::function<extenum_cb_process_subsol> cbsubsol,
-    bool dual /*=false*/,
-    bool findsubsols /*=false*/
-    );
+typedef uint64_t(extenum_fc_enumerate)(enumf maxdist, std::function<extenum_cb_set_config> cbfunc,
+                                       std::function<extenum_cb_process_sol> cbsol,
+                                       std::function<extenum_cb_process_subsol> cbsubsol,
+                                       bool dual /*=false*/, bool findsubsols /*=false*/
+                                       );
 
 // set & get external enumerator (nullptr => disabled)
 void set_external_enumerator(std::function<extenum_fc_enumerate> extenum = nullptr);
 std::function<extenum_fc_enumerate> get_external_enumerator();
 
-
-
-template<typename FT> 
-class ExternalEnumeration
+template <typename FT> class ExternalEnumeration
 {
 public:
   ExternalEnumeration(MatGSO<Integer, FT> &gso, Evaluator<FT> &evaluator)
       : _gso(gso), _evaluator(evaluator)
-  {}
-  
+  {
+  }
+
   bool enumerate(int first, int last, FT &fmaxdist, long fmaxdistexpo,
-                 const vector<enumf> &pruning = vector<enumf>(),
-                 bool dual = false);
+                 const vector<enumf> &pruning = vector<enumf>(), bool dual = false);
 
   inline uint64_t get_nodes() const { return _nodes; }
-  
+
 private:
-  void callback_set_config(
-     enumf* mu, size_t mudim, bool mutranspose, 
-     enumf* rdiag,
-     enumf* pruning);
+  void callback_set_config(enumf *mu, size_t mudim, bool mutranspose, enumf *rdiag, enumf *pruning);
 
-  enumf callback_process_sol(enumf dist, enumf* sol);
+  enumf callback_process_sol(enumf dist, enumf *sol);
 
-  void callback_process_subsol(enumf dist, enumf* subsol, int offset);
+  void callback_process_subsol(enumf dist, enumf *subsol, int offset);
 
   MatGSO<Integer, FT> &_gso;
   Evaluator<FT> &_evaluator;

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -44,7 +44,8 @@ typedef void(extenum_cb_process_subsol)(enumf dist, enumf *subsol, int offset);
 
 // prototype: extenum function
 //    return node count or ~uint64_t(0) when it fails
-typedef uint64_t(extenum_fc_enumerate)(enumf maxdist, std::function<extenum_cb_set_config> cbfunc,
+typedef uint64_t(extenum_fc_enumerate)(int dim, enumf maxdist,
+                                       std::function<extenum_cb_set_config> cbfunc,
                                        std::function<extenum_cb_process_sol> cbsol,
                                        std::function<extenum_cb_process_subsol> cbsubsol,
                                        bool dual /*=false*/, bool findsubsols /*=false*/

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -1,0 +1,103 @@
+/* 
+   (C) 2016 Marc Stevens. 
+
+   This file is part of fplll. fplll is free software: you
+   can redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License as published by the Free Software Foundation,
+   either version 2.1 of the License, or (at your option) any later version.
+
+   fplll is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with fplll. If not, see <http://www.gnu.org/licenses/>. */
+
+#ifndef FPLLL_ENUMERATE_EXT_H
+#define FPLLL_ENUMERATE_EXT_H
+
+#include <array>
+#include <fplll/enum/enumerate_base.h>
+#include <fplll/enum/evaluator.h>
+#include <fplll/gso.h>
+#include <memory>
+#include <functional>
+
+FPLLL_BEGIN_NAMESPACE
+
+/* function callback API for external enumeration library (extenum) */
+
+// prototype: function to give to extenum who can call it to fill mu and rdiag
+//    assumes mu is defined as: enumf mu[mudim][mudim];
+//    if transpose==true then will transpose mu
+typedef void (extenum_cb_set_config)(
+    enumf* mu, size_t mudim, bool mutranspose, 
+    enumf* rdiag,
+    enumf* pruning
+    ); 
+
+// prototype: function to give to extenum who can call it when it finds a solution
+//    returns new enumeration bound
+typedef enumf (extenum_cb_process_sol)(enumf dist, enumf* sol);
+
+// prototype: function to give to extenum who can call it when it finds a subsolution
+//    returns new enumeration bound
+typedef void (extenum_cb_process_subsol)(enumf dist, enumf* subsol, int offset);
+ 
+// prototype: extenum function
+//    return node count or -1ULL == ~uint64_t(0) when it fails
+typedef uint64_t (extenum_fc_enumerate)(
+    enumf maxdist,
+    std::function<extenum_cb_set_config> cbfunc, 
+    std::function<extenum_cb_process_sol> cbsol, 
+    std::function<extenum_cb_process_subsol> cbsubsol,
+    bool dual /*=false*/,
+    bool findsubsols /*=false*/
+    );
+
+// set & get external enumerator (nullptr => disabled)
+void set_external_enumerator(std::function<extenum_fc_enumerate> extenum = nullptr);
+std::function<extenum_fc_enumerate> get_external_enumerator();
+
+
+
+template<typename FT> 
+class ExternalEnumeration
+{
+public:
+  ExternalEnumeration(MatGSO<Integer, FT> &gso, Evaluator<FT> &evaluator)
+      : _gso(gso), _evaluator(evaluator)
+  {}
+  
+  bool enumerate(int first, int last, FT &fmaxdist, long fmaxdistexpo,
+                 const vector<enumf> &pruning = vector<enumf>(),
+                 bool dual = false);
+
+  inline uint64_t get_nodes() const { return _nodes; }
+  
+private:
+  void callback_set_config(
+     enumf* mu, size_t mudim, bool mutranspose, 
+     enumf* rdiag,
+     enumf* pruning);
+
+  enumf callback_process_sol(enumf dist, enumf* sol);
+
+  void callback_process_subsol(enumf dist, enumf* subsol, int offset);
+
+  MatGSO<Integer, FT> &_gso;
+  Evaluator<FT> &_evaluator;
+  vector<enumf> _pruning;
+  long _normexp;
+  uint64_t _nodes;
+
+  bool _dual;
+  int _d, _first;
+  enumf _maxdist;
+  vector<FT> _fx;
+};
+
+FPLLL_END_NAMESPACE
+
+#endif


### PR DESCRIPTION
This paves the way for using external multithreaded / mpi / GPU enumeration libraries with fplll.

You can enable an external enumeration library with
`set_external_enumerator(&external_enumeration_function)`.
When the external enumerator is called and returns -1 to indicate it can't run the job,
it automatically falls back to fplll enumeration.

This wrapper code works as expected and 
has been tested in combination with:
https://github.com/cr-marcstevens/fplll-extenum

(Note: that extenum library gives sane and very similar results, but not exactly identical to fplll enumeration yet.)
