### PR TITLE
Stable lll in bkz

### DIFF
--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -126,7 +126,7 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
 {
   // Is it already in the basis ?
   int nz_vectors = 0, i_vector = -1;
-  for (int i = 0; i < block_size; i++)
+  for (int i = block_size-1; i >=0; i--)
   {
     if (!solution[i].is_zero())
     {
@@ -135,7 +135,9 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
         i_vector = i;
     }
   }
-
+  // nz_vectors is the number of nonzero coordinates
+  // i_vector is the largest index for a \pm 1 coordinate
+    
   FPLLL_DEBUG_CHECK(nz_vectors > 0);
 
   if (nz_vectors == 1)

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -126,7 +126,7 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
 {
   // Is it already in the basis ?
   int nz_vectors = 0, i_vector = -1;
-  for (int i = block_size-1; i >=0; i--)
+  for (int i = block_size - 1; i >= 0; i--)
   {
     if (!solution[i].is_zero())
     {
@@ -137,7 +137,7 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
   }
   // nz_vectors is the number of nonzero coordinates
   // i_vector is the largest index for a \pm 1 coordinate
-    
+
   FPLLL_DEBUG_CHECK(nz_vectors > 0);
 
   if (nz_vectors == 1)
@@ -145,7 +145,7 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
     // Yes, it is another vector
     FPLLL_DEBUG_CHECK(i_vector != -1 && i_vector != 0);
     m.move_row(kappa + i_vector, kappa);
-    if (!lll_obj.size_reduction(kappa, kappa + i_vector + 1, 0))
+    if (!lll_obj.lll(0, kappa, kappa + 1, 0))
       throw lll_obj.status;
   }
   else if (i_vector != -1)
@@ -161,9 +161,9 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
     }
     m.row_op_end(d, d + 1);
     m.move_row(d, kappa);
-    m.move_row(kappa+i_vector+1, d);
+    m.move_row(kappa + i_vector + 1, d);
     m.remove_last_row();
-    if (!lll_obj.lll(0, kappa, kappa+1, 0))
+    if (!lll_obj.lll(0, kappa, kappa + 1, 0))
       throw lll_obj.status;
   }
   else
@@ -178,7 +178,7 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
     }
     m.row_op_end(d, d + 1);
     m.move_row(d, kappa);
-    if (!lll_obj.lll(kappa, kappa, kappa + block_size + 1, 0))
+    if (!lll_obj.lll(0, kappa, kappa + 1, 0))
       throw lll_obj.status;
     FPLLL_DEBUG_CHECK(m.b[kappa + block_size].is_zero());
     m.move_row(kappa + block_size, d);

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -143,7 +143,7 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
     // Yes, it is another vector
     FPLLL_DEBUG_CHECK(i_vector != -1 && i_vector != 0);
     m.move_row(kappa + i_vector, kappa);
-    if (!lll_obj.size_reduction(kappa, kappa + i_vector + 1))
+    if (!lll_obj.size_reduction(kappa, kappa + i_vector + 1, 0))
       throw lll_obj.status;
   }
   else
@@ -241,7 +241,7 @@ bool BKZReduction<FT>::svp_reduction(int kappa, int block_size, const BKZParam &
   // already in the basis). if size reduction is not called,
   // old_first might be incorrect (e.g. close to 0) and the function
   // will return an incorrect clean flag
-  if (!lll_obj.size_reduction(0, first + 1))
+  if (!lll_obj.size_reduction(0, first + 1, 0))
   {
     throw std::runtime_error(RED_STATUS_STR[lll_obj.status]);
   }
@@ -302,7 +302,7 @@ bool BKZReduction<FT>::svp_reduction(int kappa, int block_size, const BKZParam &
     remaining_probability *= (1 - pruning.expectation);
   }
 
-  if (!lll_obj.size_reduction(0, first + 1))
+  if (!lll_obj.size_reduction(0, first + 1, 0))
   {
     throw std::runtime_error(RED_STATUS_STR[lll_obj.status]);
   }

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -103,7 +103,7 @@ bool BKZReduction<FT>::svp_preprocessing(int kappa, int block_size, const BKZPar
   FPLLL_DEBUG_CHECK(param.strategies.size() > block_size);
 
   int lll_start = (param.flags & BKZ_BOUNDED_LLL) ? kappa : 0;
-  if (!lll_obj.lll(lll_start, lll_start, kappa + block_size))
+  if (!lll_obj.lll(lll_start, lll_start, kappa + block_size, 0))
   {
     throw std::runtime_error(RED_STATUS_STR[lll_obj.status]);
   }
@@ -158,7 +158,7 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
     }
     m.row_op_end(d, d + 1);
     m.move_row(d, kappa);
-    if (!lll_obj.lll(kappa, kappa, kappa + block_size + 1))
+    if (!lll_obj.lll(kappa, kappa, kappa + block_size + 1, 0))
       throw lll_obj.status;
     FPLLL_DEBUG_CHECK(m.b[kappa + block_size].is_zero());
     m.move_row(kappa + block_size, d);
@@ -221,7 +221,7 @@ bool BKZReduction<FT>::dsvp_postprocessing(int kappa, int block_size, const vect
   }
 
   m.row_op_end(kappa, kappa + d);
-  if (!lll_obj.lll(kappa, kappa, kappa + d))
+  if (!lll_obj.lll(kappa, kappa, kappa + d, 0))
   {
     return set_status(lll_obj.status);
   }
@@ -518,7 +518,7 @@ template <class FT> bool BKZReduction<FT>::bkz()
   // svp_reduction calls size_reduction, which needs to be preceeded by a
   // call to lll lower blocks to avoid seg faults
   if (sd)
-    lll_obj.lll(0, 0, num_rows);
+    lll_obj.lll(0, 0, num_rows, 0);
 
   int kappa_max = -1;
   bool clean    = true;

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -148,6 +148,24 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
     if (!lll_obj.size_reduction(kappa, kappa + i_vector + 1, 0))
       throw lll_obj.status;
   }
+  else if (i_vector != -1)
+  {
+    // No, but one coordinate is equal to \pm 1, making
+    // linear dependency easy to fix too.
+    int d = m.d;
+    m.create_row();
+    m.row_op_begin(d, d + 1);
+    for (int i = 0; i < block_size; i++)
+    {
+      m.row_addmul(d, kappa + i, solution[i]);
+    }
+    m.row_op_end(d, d + 1);
+    m.move_row(d, kappa);
+    m.move_row(kappa+i_vector+1, d);
+    m.remove_last_row();
+    if (!lll_obj.lll(0, kappa, kappa+1, 0))
+      throw lll_obj.status;
+  }
   else
   {
     // No, general case

--- a/fplll/lll.cpp
+++ b/fplll/lll.cpp
@@ -68,10 +68,8 @@ bool LLLReduction<ZT, FT>::lll(int kappa_min, int kappa_start, int kappa_end,
     m.move_row(kappa_min, kappa_end - 1 - zeros);
   }
 
-  if (zeros < d &&
-      ((kappa_start > 0
-	&& !babai(kappa_start, kappa_start, size_reduction_start))
-       || !m.update_gso_row(kappa_start)))
+  if (zeros < d && ((kappa_start > 0 && !babai(kappa_start, kappa_start, size_reduction_start)) ||
+                    !m.update_gso_row(kappa_start)))
   {
     final_kappa = kappa_start;
     return false;

--- a/fplll/lll.cpp
+++ b/fplll/lll.cpp
@@ -69,7 +69,9 @@ bool LLLReduction<ZT, FT>::lll(int kappa_min, int kappa_start, int kappa_end,
   }
 
   if (zeros < d &&
-      ((kappa_start > 0 && !babai(kappa_start, kappa_start)) || !m.update_gso_row(kappa_start)))
+      ((kappa_start > 0
+	&& !babai(kappa_start, kappa_start, size_reduction_start))
+       || !m.update_gso_row(kappa_start)))
   {
     final_kappa = kappa_start;
     return false;
@@ -91,7 +93,7 @@ bool LLLReduction<ZT, FT>::lll(int kappa_min, int kappa_start, int kappa_end,
       kappa_max = kappa;
       if (enable_early_red && is_power_of_2(kappa) && kappa > last_early_red)
       {
-        if (!early_reduction(kappa))
+        if (!early_reduction(kappa, size_reduction_start))
         {
           final_kappa = kappa;
           return false;

--- a/fplll/lll.h
+++ b/fplll/lll.h
@@ -118,8 +118,7 @@ inline bool LLLReduction<ZT, FT>::size_reduction(int kappa_min, int kappa_end,
 }
 
 template <class ZT, class FT>
-inline bool LLLReduction<ZT, FT>::early_reduction(int start,
-						  int size_reduction_start)
+inline bool LLLReduction<ZT, FT>::early_reduction(int start, int size_reduction_start)
 {
   m.lock_cols();
   if (verbose)

--- a/fplll/lll.h
+++ b/fplll/lll.h
@@ -83,7 +83,7 @@ private:
   */
 
   bool babai(int kappa, int size_reduction_end, int size_reduction_start = 0);
-  inline bool early_reduction(int start);
+  inline bool early_reduction(int start, int size_reduction_start = 0);
   inline void print_params();
   inline bool set_status(int new_status);
 
@@ -117,7 +117,9 @@ inline bool LLLReduction<ZT, FT>::size_reduction(int kappa_min, int kappa_end,
   return set_status(RED_SUCCESS);
 }
 
-template <class ZT, class FT> inline bool LLLReduction<ZT, FT>::early_reduction(int start)
+template <class ZT, class FT>
+inline bool LLLReduction<ZT, FT>::early_reduction(int start,
+						  int size_reduction_start)
 {
   m.lock_cols();
   if (verbose)
@@ -126,7 +128,7 @@ template <class ZT, class FT> inline bool LLLReduction<ZT, FT>::early_reduction(
   }
   for (int i = start; i < m.d; i++)
   {
-    if (!babai(i, start))
+    if (!babai(i, start, size_reduction_start))
       return false;
   }
   m.unlock_cols();


### PR DESCRIPTION
Enables babai (i.e., LLL size-reduction) not  to use the first basis vectors.
Changes enumeration post_processing in BKZ
    * if the solution vector contains a 1, use this to eliminate the linear dependency
    * if not, proceed as before