### PR TITLE
Gaussian Heuristic repaired and renamed

### DIFF
--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -90,7 +90,7 @@ const Pruning &BKZReduction<FT>::get_pruning(int kappa, int block_size, const BK
   FT max_dist    = m.get_r_exp(kappa, kappa, max_dist_expo);
   FT gh_max_dist = max_dist;
   FT root_det    = m.get_root_det(kappa, kappa + block_size);
-  gaussian_heuristic(gh_max_dist, max_dist_expo, block_size, root_det, 1.0);
+  adjust_radius_to_gh_bound(gh_max_dist, max_dist_expo, block_size, root_det, 1.0);
   return strat.get_pruning(max_dist.get_d() * pow(2, max_dist_expo),
                            gh_max_dist.get_d() * pow(2, max_dist_expo));
 }
@@ -273,7 +273,7 @@ bool BKZReduction<FT>::svp_reduction(int kappa, int block_size, const BKZParam &
     if ((par.flags & BKZ_GH_BND) && block_size > 30)
     {
       FT root_det = m.get_root_det(kappa, kappa + block_size);
-      gaussian_heuristic(max_dist, max_dist_expo, block_size, root_det, par.gh_factor);
+      adjust_radius_to_gh_bound(max_dist, max_dist_expo, block_size, root_det, par.gh_factor);
     }
 
     const Pruning &pruning = get_pruning(kappa, block_size, par);

--- a/fplll/gso.cpp
+++ b/fplll/gso.cpp
@@ -597,8 +597,8 @@ void gaussian_heuristic(FT &max_dist, long max_dist_expo, int block_size, const 
                         double gh_factor)
 {
   double t = (double)block_size / 2.0 + 1;
-  t        = tgamma(t);
-  t        = pow(t, 2.0 / (double)block_size);
+  t        = lgamma(t);
+  t        = pow(M_E ,t * 2.0 / (double)block_size);
   t        = t / M_PI;
   FT f     = t;
   f        = f * root_det;

--- a/fplll/gso.cpp
+++ b/fplll/gso.cpp
@@ -594,11 +594,11 @@ FT MatGSO<ZT, FT>::get_slide_potential(int start_row, int end_row, int block_siz
 
 template <class FT>
 void adjust_radius_to_gh_bound(FT &max_dist, long max_dist_expo, int block_size, const FT &root_det,
-                        double gh_factor)
+                               double gh_factor)
 {
   double t = (double)block_size / 2.0 + 1;
   t        = lgamma(t);
-  t        = pow(M_E ,t * 2.0 / (double)block_size);
+  t        = pow(M_E, t * 2.0 / (double)block_size);
   t        = t / M_PI;
   FT f     = t;
   f        = f * root_det;
@@ -614,17 +614,18 @@ template class MatGSO<Z_NR<long>, FP_NR<double>>;
 template class MatGSO<Z_NR<double>, FP_NR<double>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<double>>;
 template void adjust_radius_to_gh_bound<FP_NR<double>>(FP_NR<double> &max_dist, long max_dist_expo,
-                                                int block_size, const FP_NR<double> &root_det,
-                                                double gh_factor);
+                                                       int block_size,
+                                                       const FP_NR<double> &root_det,
+                                                       double gh_factor);
 
 #ifdef FPLLL_WITH_LONG_DOUBLE
 template class MatGSO<Z_NR<long>, FP_NR<long double>>;
 template class MatGSO<Z_NR<double>, FP_NR<long double>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<long double>>;
 template void adjust_radius_to_gh_bound<FP_NR<long double>>(FP_NR<long double> &max_dist,
-                                                     long max_dist_expo, int block_size,
-                                                     const FP_NR<long double> &root_det,
-                                                     double gh_factor);
+                                                            long max_dist_expo, int block_size,
+                                                            const FP_NR<long double> &root_det,
+                                                            double gh_factor);
 
 #endif
 
@@ -632,15 +633,17 @@ template void adjust_radius_to_gh_bound<FP_NR<long double>>(FP_NR<long double> &
 template class MatGSO<Z_NR<long>, FP_NR<dd_real>>;
 template class MatGSO<Z_NR<double>, FP_NR<dd_real>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<dd_real>>;
-template void adjust_radius_to_gh_bound<FP_NR<dd_real>>(FP_NR<dd_real> &max_dist, long max_dist_expo,
-                                                 int block_size, const FP_NR<dd_real> &root_det,
-                                                 double gh_factor);
+template void adjust_radius_to_gh_bound<FP_NR<dd_real>>(FP_NR<dd_real> &max_dist,
+                                                        long max_dist_expo, int block_size,
+                                                        const FP_NR<dd_real> &root_det,
+                                                        double gh_factor);
 template class MatGSO<Z_NR<long>, FP_NR<qd_real>>;
 template class MatGSO<Z_NR<double>, FP_NR<qd_real>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<qd_real>>;
-template void adjust_radius_to_gh_bound<FP_NR<qd_real>>(FP_NR<qd_real> &max_dist, long max_dist_expo,
-                                                 int block_size, const FP_NR<qd_real> &root_det,
-                                                 double gh_factor);
+template void adjust_radius_to_gh_bound<FP_NR<qd_real>>(FP_NR<qd_real> &max_dist,
+                                                        long max_dist_expo, int block_size,
+                                                        const FP_NR<qd_real> &root_det,
+                                                        double gh_factor);
 #endif
 
 #ifdef FPLLL_WITH_DPE
@@ -648,15 +651,16 @@ template class MatGSO<Z_NR<long>, FP_NR<dpe_t>>;
 template class MatGSO<Z_NR<double>, FP_NR<dpe_t>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t>>;
 template void adjust_radius_to_gh_bound<FP_NR<dpe_t>>(FP_NR<dpe_t> &max_dist, long max_dist_expo,
-                                               int block_size, const FP_NR<dpe_t> &root_det,
-                                               double gh_factor);
+                                                      int block_size, const FP_NR<dpe_t> &root_det,
+                                                      double gh_factor);
 #endif
 
 template class MatGSO<Z_NR<long>, FP_NR<mpfr_t>>;
 template class MatGSO<Z_NR<double>, FP_NR<mpfr_t>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t>>;
 template void adjust_radius_to_gh_bound<FP_NR<mpfr_t>>(FP_NR<mpfr_t> &max_dist, long max_dist_expo,
-                                                int block_size, const FP_NR<mpfr_t> &root_det,
-                                                double gh_factor);
+                                                       int block_size,
+                                                       const FP_NR<mpfr_t> &root_det,
+                                                       double gh_factor);
 
 FPLLL_END_NAMESPACE

--- a/fplll/gso.cpp
+++ b/fplll/gso.cpp
@@ -593,7 +593,7 @@ FT MatGSO<ZT, FT>::get_slide_potential(int start_row, int end_row, int block_siz
 }
 
 template <class FT>
-void gaussian_heuristic(FT &max_dist, long max_dist_expo, int block_size, const FT &root_det,
+void adjust_radius_to_gh_bound(FT &max_dist, long max_dist_expo, int block_size, const FT &root_det,
                         double gh_factor)
 {
   double t = (double)block_size / 2.0 + 1;
@@ -613,7 +613,7 @@ void gaussian_heuristic(FT &max_dist, long max_dist_expo, int block_size, const 
 template class MatGSO<Z_NR<long>, FP_NR<double>>;
 template class MatGSO<Z_NR<double>, FP_NR<double>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<double>>;
-template void gaussian_heuristic<FP_NR<double>>(FP_NR<double> &max_dist, long max_dist_expo,
+template void adjust_radius_to_gh_bound<FP_NR<double>>(FP_NR<double> &max_dist, long max_dist_expo,
                                                 int block_size, const FP_NR<double> &root_det,
                                                 double gh_factor);
 
@@ -621,7 +621,7 @@ template void gaussian_heuristic<FP_NR<double>>(FP_NR<double> &max_dist, long ma
 template class MatGSO<Z_NR<long>, FP_NR<long double>>;
 template class MatGSO<Z_NR<double>, FP_NR<long double>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<long double>>;
-template void gaussian_heuristic<FP_NR<long double>>(FP_NR<long double> &max_dist,
+template void adjust_radius_to_gh_bound<FP_NR<long double>>(FP_NR<long double> &max_dist,
                                                      long max_dist_expo, int block_size,
                                                      const FP_NR<long double> &root_det,
                                                      double gh_factor);
@@ -632,13 +632,13 @@ template void gaussian_heuristic<FP_NR<long double>>(FP_NR<long double> &max_dis
 template class MatGSO<Z_NR<long>, FP_NR<dd_real>>;
 template class MatGSO<Z_NR<double>, FP_NR<dd_real>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<dd_real>>;
-template void gaussian_heuristic<FP_NR<dd_real>>(FP_NR<dd_real> &max_dist, long max_dist_expo,
+template void adjust_radius_to_gh_bound<FP_NR<dd_real>>(FP_NR<dd_real> &max_dist, long max_dist_expo,
                                                  int block_size, const FP_NR<dd_real> &root_det,
                                                  double gh_factor);
 template class MatGSO<Z_NR<long>, FP_NR<qd_real>>;
 template class MatGSO<Z_NR<double>, FP_NR<qd_real>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<qd_real>>;
-template void gaussian_heuristic<FP_NR<qd_real>>(FP_NR<qd_real> &max_dist, long max_dist_expo,
+template void adjust_radius_to_gh_bound<FP_NR<qd_real>>(FP_NR<qd_real> &max_dist, long max_dist_expo,
                                                  int block_size, const FP_NR<qd_real> &root_det,
                                                  double gh_factor);
 #endif
@@ -647,7 +647,7 @@ template void gaussian_heuristic<FP_NR<qd_real>>(FP_NR<qd_real> &max_dist, long 
 template class MatGSO<Z_NR<long>, FP_NR<dpe_t>>;
 template class MatGSO<Z_NR<double>, FP_NR<dpe_t>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<dpe_t>>;
-template void gaussian_heuristic<FP_NR<dpe_t>>(FP_NR<dpe_t> &max_dist, long max_dist_expo,
+template void adjust_radius_to_gh_bound<FP_NR<dpe_t>>(FP_NR<dpe_t> &max_dist, long max_dist_expo,
                                                int block_size, const FP_NR<dpe_t> &root_det,
                                                double gh_factor);
 #endif
@@ -655,7 +655,7 @@ template void gaussian_heuristic<FP_NR<dpe_t>>(FP_NR<dpe_t> &max_dist, long max_
 template class MatGSO<Z_NR<long>, FP_NR<mpfr_t>>;
 template class MatGSO<Z_NR<double>, FP_NR<mpfr_t>>;
 template class MatGSO<Z_NR<mpz_t>, FP_NR<mpfr_t>>;
-template void gaussian_heuristic<FP_NR<mpfr_t>>(FP_NR<mpfr_t> &max_dist, long max_dist_expo,
+template void adjust_radius_to_gh_bound<FP_NR<mpfr_t>>(FP_NR<mpfr_t> &max_dist, long max_dist_expo,
                                                 int block_size, const FP_NR<mpfr_t> &root_det,
                                                 double gh_factor);
 

--- a/fplll/gso.h
+++ b/fplll/gso.h
@@ -45,7 +45,7 @@ enum MatGSOFlags
 */
 
 template <class FT>
-void gaussian_heuristic(FT &max_dist, long max_dist_expo, int block_size, const FT &root_det,
+void adjust_radius_to_gh_bound(FT &max_dist, long max_dist_expo, int block_size, const FT &root_det,
                         double gh_factor);
 
 /**

--- a/fplll/gso.h
+++ b/fplll/gso.h
@@ -46,7 +46,7 @@ enum MatGSOFlags
 
 template <class FT>
 void adjust_radius_to_gh_bound(FT &max_dist, long max_dist_expo, int block_size, const FT &root_det,
-                        double gh_factor);
+                               double gh_factor);
 
 /**
  * MatGSO provides an interface for performing elementary operations on a basis


### PR DESCRIPTION
repairing gaussian_heuristic to handle very large dimension (switching from tgamma to lgamma to avoid exponent overflow in double).

Rename the function to something more faithful to its behavior : adjust_radius_to_gh_bound .