### PR TITLE
Don't test long double functionality without FPLLL_WITH_LONG_DOUBLE

### DIFF
--- a/tests/test_nr.cpp
+++ b/tests/test_nr.cpp
@@ -72,7 +72,9 @@ int main(int argc, char *argv[])
 
   int status = 0;
   status |= test_arithmetic<FP_NR<double>>();
+#ifdef FPLLL_WITH_LONG_DOUBLE
   status |= test_arithmetic<FP_NR<long double>>();
+#endif
 #ifdef FPLLL_WITH_DPE
   status |= test_arithmetic<FP_NR<dpe_t>>();
 #endif
@@ -83,7 +85,9 @@ int main(int argc, char *argv[])
   status |= test_arithmetic<FP_NR<mpfr_t>>();
 
   status |= test_std<FP_NR<double>>();
+#ifdef FPLLL_WITH_LONG_DOUBLE
   status |= test_std<FP_NR<long double>>();
+#endif
 #ifdef FPLLL_WITH_DPE
   status |= test_std<FP_NR<dpe_t>>();
 #endif
@@ -94,7 +98,9 @@ int main(int argc, char *argv[])
   status |= test_std<FP_NR<mpfr_t>>();
 
   status |= test_root<FP_NR<double>>();
+#ifdef FPLLL_WITH_LONG_DOUBLE
   status |= test_root<FP_NR<long double>>();
+#endif
 #ifdef FPLLL_WITH_QD
   status |= test_root<FP_NR<dd_real>>();
   status |= test_root<FP_NR<qd_real>>();
@@ -102,7 +108,9 @@ int main(int argc, char *argv[])
   status |= test_root<FP_NR<mpfr_t>>();
 
   status |= test_str<FP_NR<double>>();
+#ifdef FPLLL_WITH_LONG_DOUBLE
   status |= test_str<FP_NR<long double>>();
+#endif
 #ifdef FPLLL_WITH_DPE
   status |= test_str<FP_NR<dpe_t>>();
 #endif

--- a/tests/test_pruner.cpp
+++ b/tests/test_pruner.cpp
@@ -520,20 +520,25 @@ int main(int argc, char *argv[])
   cerr << endl << "d" << endl;
   status += test_unpruned<FP_NR<double>>();
   print_status(status);
+#ifdef FPLLL_WITH_LONG_DOUBLE
   cerr << endl << "ld" << endl;
   status += test_unpruned<FP_NR<long double>>();
   print_status(status);
+#endif
   cerr << endl << "MPRF" << endl;
   status += test_unpruned<FP_NR<mpfr_t>>();
   print_status(status);
 
   status += test_prepruned<FP_NR<double>>();
   print_status(status);
+#ifdef FPLLL_WITH_LONG_DOUBLE
   status += test_prepruned<FP_NR<long double>>();
   print_status(status);
+#endif
   status += test_prepruned<FP_NR<mpfr_t>>();
   print_status(status);
 
+#ifdef FPLLL_WITH_LONG_DOUBLE
   Pruner<FP_NR<long double>>::TestPruner tp;
   status += tp.test_enforce();
   print_status(status);
@@ -543,6 +548,7 @@ int main(int argc, char *argv[])
   print_status(status);
   status += tp.test_relative_volume();
   print_status(status);
+#endif
 
 #ifdef FPLLL_WITH_QD
   Pruner<FP_NR<dd_real>>::TestPruner tp2;


### PR DESCRIPTION
Self-explanatory--don't compile tests that use `long double` where that isn't supported (see #212).

With this fixed, `make check` can pass on Cygwin.