### PR TITLE
Allow the recursive enumerate feature to be disabled at configure time

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -124,6 +124,13 @@ AC_ARG_WITH(max-enumeration-dimension,
 
 AC_DEFINE_UNQUOTED([FPLLL_MAX_ENUM_DIMENSION], $max_enumeration_dimension, [maximum supported enumeration dimension])
 
+AC_ARG_ENABLE(recursive-enum,
+        AS_HELP_STRING([--disable-recursive-enum],
+         [Disable recursive enumeration]))
+
+AS_IF([test "x$enable_recursive_enum" != "xno"], [
+        AC_DEFINE([FPLLL_WITH_RECURSIVE_ENUM], [1], [recursive enumeration enabled])])
+
 # Store version numbers in header
 
 AC_DEFINE_UNQUOTED([FPLLL_MAJOR_VERSION],[$FPLLL_MAJOR_VERSION],[major version])

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -32,7 +32,6 @@ inline void roundto(int &dest, const double &src) { dest = (int)round(src); }
 inline void roundto(double &dest, const double &src) { dest = round(src); }
 
 /* config */
-#define FPLLL_WITH_RECURSIVE_ENUM 1
 #define MAXTEMPLATEDDIMENSION 80  // unused
 //#define FORCE_ENUM_INLINE // not recommended
 /* end config */

--- a/fplll/fplll_config.h.in
+++ b/fplll/fplll_config.h.in
@@ -25,4 +25,7 @@
 /* Maximum supported enumeration dimension */
 #define FPLLL_MAX_ENUM_DIMENSION @FPLLL_MAX_ENUM_DIMENSION@
 
+/* Recursive enumeration enabled */
+#undef FPLLL_WITH_RECURSIVE_ENUM
+
 #endif //FPLLL_CONFIG__H


### PR DESCRIPTION
Since this feature--admittedly I don't fully understand what it does--was added (#191) libfplll does not build on Cygwin.

This is in part for two reasons: it results in a huge number of binary sections (>40000) in the enumerate_base.o object file.  On Windows this is a known problem due to limitation in the COFF file format.  This can be gotten around somewhat with the `-mbig-obj` flag to the GNU assembler, and in the past that's worked for me to get around this problem.

In this case, however, while I can get the file to compile/assemble with `-mbig-obj`, linking libfplll fails.  I haven't run into this problem before (maybe just by luck?) but as far as I can tell it seems to be a bug *somewhere* in the (slightly old) bfd/binutils on Cygwin.  It seems to be using a signed short somewhere for section numbers, and getting very confused when trying to resolve symbols whose values are in sections > 2^15.

All of the above is just background to say: this feature is broken on Cygwin for reasons mostly outside our control (linker bugs).  Since it seems to be optional anyways the easiest work-around for now is to just disable it on Cygwin.  However, I noticed in doing so that there's no way to do right now except to manually edit the header, so I thought it might be nice to have a `configure` flag for it (in particular, since I might be interested in experimenting with this more later on different versions of GNU tools).