### PR TITLE
Repairing test_pruner for #245

### DIFF
--- a/tests/test_pruner.cpp
+++ b/tests/test_pruner.cpp
@@ -337,7 +337,7 @@ template <class FT> int test_auto_prune(size_t n)
   print_status(status);
   status += !(pruning.expectation < 100.0);
   print_status(status);
-  status += !(pruning.radius_factor >= 1.0);
+  status += !(pruning.radius_factor >= .999);
   print_status(status);
   status += !(pruning.coefficients[0] == 1.0);
   print_status(status);
@@ -354,7 +354,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << "radius " << radius_d << endl;
   prune<FT>(pruning, radius_d, overhead, 0.3, r, PRUNER_METHOD_GRADIENT,
             PRUNER_METRIC_PROBABILITY_OF_SHORTEST, true);
-  status += !(pruning.expectation <= 1.0);
+  status += !(pruning.expectation <= 1.001);
   print_status(status);
   cerr << "Probability " << pruning.expectation << endl;
   cost = 0.;
@@ -368,7 +368,7 @@ template <class FT> int test_auto_prune(size_t n)
 
   status += !(pruning.expectation > 0.0);
   print_status(status);
-  status += !(pruning.radius_factor >= 1.0);
+  status += !(pruning.radius_factor >= .999);
   print_status(status);
   status += !(pruning.coefficients[0] == 1.0);
   print_status(status);
@@ -377,7 +377,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << "radius " << radius_d << endl;
   prune<FT>(pruning, radius_d, overhead, 0.01, r, PRUNER_METHOD_GRADIENT,
             PRUNER_METRIC_PROBABILITY_OF_SHORTEST, false);
-  status += !(pruning.expectation <= 1.0);
+  status += !(pruning.expectation <= 1.001);
   print_status(status);
   cerr << "Probability " << pruning.expectation << endl;
   cost = 0.;
@@ -390,7 +390,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << endl << "Predicted Total Cost " << cost << endl;
   status += !(pruning.expectation > 0.0);
   print_status(status);
-  status += !(pruning.radius_factor >= 1.0);
+  status += !(pruning.radius_factor >= .999);
   print_status(status);
   status += !(pruning.coefficients[0] == 1.0);
   print_status(status);
@@ -399,7 +399,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << "radius " << radius_d << endl;
   prune<FT>(pruning, radius_d, overhead, 0.3, r, PRUNER_METHOD_NM,
             PRUNER_METRIC_PROBABILITY_OF_SHORTEST, true);
-  status += !(pruning.expectation <= 1.0);
+  status += !(pruning.expectation <= 1.001);
   print_status(status);
   cerr << "Probability " << pruning.expectation << endl;
   cost = 0.;
@@ -412,7 +412,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << endl << "Predicted Total Cost " << cost << endl;
   status += !(pruning.expectation > 0.0);
   print_status(status);
-  status += !(pruning.radius_factor >= 1.0);
+  status += !(pruning.radius_factor >= .999);
   print_status(status);
   status += !(pruning.coefficients[0] == 1.0);
   print_status(status);
@@ -421,7 +421,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << "radius " << radius_d << endl;
   prune<FT>(pruning, radius_d, overhead, 0.01, r, PRUNER_METHOD_GRADIENT,
             PRUNER_METRIC_PROBABILITY_OF_SHORTEST, false);
-  status += !(pruning.expectation <= 1.0);
+  status += !(pruning.expectation <= 1.001);
   print_status(status);
   cerr << "Probability " << pruning.expectation << endl;
   cost = 0.;
@@ -434,7 +434,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << endl << "Predicted Total Cost " << cost << endl;
   status += !(pruning.expectation > 0.0);
   print_status(status);
-  status += !(pruning.radius_factor >= 1.0);
+  status += !(pruning.radius_factor >= .999);
   print_status(status);
   status += !(pruning.coefficients[0] == 1.0);
   print_status(status);
@@ -443,7 +443,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << "radius " << radius_d << endl;
   prune<FT>(pruning, radius_d, overhead, 0.3, r, PRUNER_METHOD_HYBRID,
             PRUNER_METRIC_PROBABILITY_OF_SHORTEST, true);
-  status += !(pruning.expectation <= 1.0);
+  status += !(pruning.expectation <= 1.001);
   print_status(status);
   cerr << "Probability " << pruning.expectation << endl;
   cost = 0.;
@@ -456,7 +456,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << endl << "Predicted Total Cost " << cost << endl;
   status += !(pruning.expectation > 0.0);
   print_status(status);
-  status += !(pruning.radius_factor >= 1.0);
+  status += !(pruning.radius_factor >= .999);
   print_status(status);
   status += !(pruning.coefficients[0] == 1.0);
   print_status(status);
@@ -465,7 +465,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << "radius " << radius_d << endl;
   prune<FT>(pruning, radius_d, overhead, 0.01, r, PRUNER_METHOD_GRADIENT,
             PRUNER_METRIC_PROBABILITY_OF_SHORTEST, false);
-  status += !(pruning.expectation <= 1.0);
+  status += !(pruning.expectation <= 1.001);
   print_status(status);
   cerr << "Probability " << pruning.expectation << endl;
   cost = 0.;
@@ -478,7 +478,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << endl << "Predicted Total Cost " << cost << endl;
   status += !(pruning.expectation > 0.0);
   print_status(status);
-  status += !(pruning.radius_factor >= 1.0);
+  status += !(pruning.radius_factor >= .999);
   print_status(status);
   status += !(pruning.coefficients[0] == 1.0);
   print_status(status);
@@ -486,7 +486,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << endl << "Reprune Hybrid " << endl;
   prune<FT>(pruning, radius_d, overhead, 0.3, r, PRUNER_METHOD_GRADIENT,
             PRUNER_METRIC_PROBABILITY_OF_SHORTEST, false);
-  status += !(pruning.expectation <= 1.0);
+  status += !(pruning.expectation <= 1.001);
   print_status(status);
   cerr << "Probability " << pruning.expectation << endl;
   cost = 0.;
@@ -499,7 +499,7 @@ template <class FT> int test_auto_prune(size_t n)
   cerr << endl << "Predicted Total Cost " << cost << endl;
   status += !(pruning.expectation > 0.0);
   print_status(status);
-  status += !(pruning.radius_factor >= 1.0);
+  status += !(pruning.radius_factor >= .999);
   print_status(status);
   status += !(pruning.coefficients[0] == 1.0);
   print_status(status);


### PR DESCRIPTION
Inequalities in test_pruner now tolerates small numerical errors.
The test still pass on my 64 bits machine. Not tested yet on a 32 bit env.