### PR TITLE
BKZ with Z_NR<long>

### DIFF
--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -26,8 +26,8 @@
 
 FPLLL_BEGIN_NAMESPACE
 
-template <class FT>
-BKZReduction<FT>::BKZReduction(MatGSO<Integer, FT> &m, LLLReduction<Integer, FT> &lll_obj,
+template <class ZT, class FT>
+BKZReduction<ZT, FT>::BKZReduction(MatGSO<ZT, FT> &m, LLLReduction<ZT, FT> &lll_obj,
                                const BKZParam &param)
     : status(RED_SUCCESS), nodes(0), param(param), m(m), lll_obj(lll_obj), algorithm(NULL),
       cputime_start(0)
@@ -38,9 +38,9 @@ BKZReduction<FT>::BKZReduction(MatGSO<Integer, FT> &m, LLLReduction<Integer, FT>
   this->delta = param.delta;
 }
 
-template <class FT> BKZReduction<FT>::~BKZReduction() {}
+template <class ZT, class FT> BKZReduction<ZT, FT>::~BKZReduction() {}
 
-template <class FT> void BKZReduction<FT>::rerandomize_block(int min_row, int max_row, int density)
+template <class ZT, class FT> void BKZReduction<ZT, FT>::rerandomize_block(int min_row, int max_row, int density)
 {
   if (max_row - min_row < 2)
     return;
@@ -78,8 +78,8 @@ template <class FT> void BKZReduction<FT>::rerandomize_block(int min_row, int ma
   return;
 }
 
-template <class FT>
-const Pruning &BKZReduction<FT>::get_pruning(int kappa, int block_size, const BKZParam &par) const
+template <class ZT, class FT>
+const Pruning &BKZReduction<ZT, FT>::get_pruning(int kappa, int block_size, const BKZParam &par) const
 {
 
   FPLLL_DEBUG_CHECK(param.strategies.size() > block_size);
@@ -95,8 +95,8 @@ const Pruning &BKZReduction<FT>::get_pruning(int kappa, int block_size, const BK
                            gh_max_dist.get_d() * pow(2, max_dist_expo));
 }
 
-template <class FT>
-bool BKZReduction<FT>::svp_preprocessing(int kappa, int block_size, const BKZParam &param)
+template <class ZT, class FT>
+bool BKZReduction<ZT, FT>::svp_preprocessing(int kappa, int block_size, const BKZParam &param)
 {
   bool clean = true;
 
@@ -124,8 +124,8 @@ bool BKZReduction<FT>::svp_preprocessing(int kappa, int block_size, const BKZPar
   return clean;
 }
 
-template <class FT>
-bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vector<FT> &solution,
+template <class ZT, class FT>
+bool BKZReduction<ZT, FT>::svp_postprocessing(int kappa, int block_size, const vector<FT> &solution,
                                           bool dual)
 {
   // Is it already in the basis ?
@@ -199,8 +199,8 @@ bool BKZReduction<FT>::svp_postprocessing(int kappa, int block_size, const vecto
   return false;
 }
 
-template <class FT>
-bool BKZReduction<FT>::svp_postprocessing_generic(int kappa, int block_size,
+template <class ZT, class FT>
+bool BKZReduction<ZT, FT>::svp_postprocessing_generic(int kappa, int block_size,
                                                   const vector<FT> &solution, bool dual)
 {
   vector<FT> x = solution;
@@ -264,8 +264,8 @@ bool BKZReduction<FT>::svp_postprocessing_generic(int kappa, int block_size,
   return false;
 }
 
-template <class FT>
-bool BKZReduction<FT>::svp_reduction(int kappa, int block_size, const BKZParam &par, bool dual)
+template <class ZT, class FT>
+bool BKZReduction<ZT, FT>::svp_reduction(int kappa, int block_size, const BKZParam &par, bool dual)
 {
   int first = dual ? kappa + block_size - 1 : kappa;
 
@@ -315,7 +315,7 @@ bool BKZReduction<FT>::svp_reduction(int kappa, int block_size, const BKZParam &
 
     FPLLL_DEBUG_CHECK(pruning.metric == PRUNER_METRIC_PROBABILITY_OF_SHORTEST)
     evaluator.solutions.clear();
-    Enumeration<Integer, FT> enum_obj(m, evaluator);
+    Enumeration<ZT, FT> enum_obj(m, evaluator);
     enum_obj.enumerate(kappa, kappa + block_size, max_dist, max_dist_expo, vector<FT>(),
                        vector<enumxt>(), pruning.coefficients, dual);
     nodes += enum_obj.get_nodes();
@@ -342,8 +342,8 @@ bool BKZReduction<FT>::svp_reduction(int kappa, int block_size, const BKZParam &
   return (dual) ? (old_first >= new_first) : (old_first <= new_first);
 }
 
-template <class FT>
-bool BKZReduction<FT>::tour(const int loop, int &kappa_max, const BKZParam &par, int min_row,
+template <class ZT, class FT>
+bool BKZReduction<ZT, FT>::tour(const int loop, int &kappa_max, const BKZParam &par, int min_row,
                             int max_row)
 {
   bool clean = true;
@@ -367,8 +367,8 @@ bool BKZReduction<FT>::tour(const int loop, int &kappa_max, const BKZParam &par,
   return clean;
 }
 
-template <class FT>
-bool BKZReduction<FT>::trunc_tour(int &kappa_max, const BKZParam &par, int min_row, int max_row)
+template <class ZT, class FT>
+bool BKZReduction<ZT, FT>::trunc_tour(int &kappa_max, const BKZParam &par, int min_row, int max_row)
 {
   bool clean     = true;
   int block_size = par.block_size;
@@ -386,8 +386,8 @@ bool BKZReduction<FT>::trunc_tour(int &kappa_max, const BKZParam &par, int min_r
   return clean;
 }
 
-template <class FT>
-bool BKZReduction<FT>::trunc_dtour(const BKZParam &par, int min_row, int max_row)
+template <class ZT, class FT>
+bool BKZReduction<ZT, FT>::trunc_dtour(const BKZParam &par, int min_row, int max_row)
 {
   bool clean     = true;
   int block_size = par.block_size;
@@ -400,8 +400,8 @@ bool BKZReduction<FT>::trunc_dtour(const BKZParam &par, int min_row, int max_row
   return clean;
 }
 
-template <class FT>
-bool BKZReduction<FT>::hkz(int &kappa_max, const BKZParam &param, int min_row, int max_row)
+template <class ZT, class FT>
+bool BKZReduction<ZT, FT>::hkz(int &kappa_max, const BKZParam &param, int min_row, int max_row)
 {
   bool clean = true;
   for (int kappa = min_row; kappa < max_row - 1; ++kappa)
@@ -424,8 +424,8 @@ bool BKZReduction<FT>::hkz(int &kappa_max, const BKZParam &param, int min_row, i
   return clean;
 }
 
-template <class FT>
-bool BKZReduction<FT>::sd_tour(const int loop, const BKZParam &par, int min_row, int max_row)
+template <class ZT, class FT>
+bool BKZReduction<ZT, FT>::sd_tour(const int loop, const BKZParam &par, int min_row, int max_row)
 {
   int dummy_kappa_max = num_rows;
   bool clean          = true;
@@ -449,8 +449,8 @@ bool BKZReduction<FT>::sd_tour(const int loop, const BKZParam &par, int min_row,
   return clean;
 }
 
-template <class FT>
-bool BKZReduction<FT>::slide_tour(const int loop, const BKZParam &par, int min_row, int max_row)
+template <class ZT, class FT>
+bool BKZReduction<ZT, FT>::slide_tour(const int loop, const BKZParam &par, int min_row, int max_row)
 {
   int p = (max_row - min_row) / par.block_size;
   if ((max_row - min_row) % par.block_size)
@@ -508,7 +508,7 @@ bool BKZReduction<FT>::slide_tour(const int loop, const BKZParam &par, int min_r
   return false;
 }
 
-template <class FT> bool BKZReduction<FT>::bkz()
+template <class ZT, class FT> bool BKZReduction<ZT, FT>::bkz()
 {
   int flags        = param.flags;
   int final_status = RED_SUCCESS;
@@ -534,7 +534,7 @@ template <class FT> bool BKZReduction<FT>::bkz()
 
   int i = 0;
 
-  BKZAutoAbort<FT> auto_abort(m, num_rows);
+  BKZAutoAbort<ZT, FT> auto_abort(m, num_rows);
 
   if (sd && !(flags & (BKZ_MAX_LOOPS | BKZ_MAX_TIME | BKZ_AUTO_ABORT)))
   {
@@ -655,7 +655,7 @@ template <class FT> bool BKZReduction<FT>::bkz()
   return set_status(final_status);
 }
 
-template <class FT> void BKZReduction<FT>::print_tour(const int loop, int min_row, int max_row)
+template <class ZT, class FT> void BKZReduction<ZT, FT>::print_tour(const int loop, int min_row, int max_row)
 {
   FT r0;
   Float fr0;
@@ -671,7 +671,7 @@ template <class FT> void BKZReduction<FT>::print_tour(const int loop, int min_ro
   cerr << ", log2(nodes) = " << std::setw(9) << std::setprecision(6) << log2(nodes) << endl;
 }
 
-template <class FT> void BKZReduction<FT>::print_params(const BKZParam &param, ostream &out)
+template <class ZT, class FT> void BKZReduction<ZT, FT>::print_params(const BKZParam &param, ostream &out)
 {
   out << "block size: " << std::setw(3) << param.block_size << ", ";
   out << "flags: 0x" << std::setw(4) << setfill('0') << std::hex << param.flags << ", " << std::dec
@@ -692,7 +692,7 @@ template <class FT> void BKZReduction<FT>::print_params(const BKZParam &param, o
   out << endl;
 }
 
-template <class FT> bool BKZReduction<FT>::set_status(int new_status)
+template <class ZT, class FT> bool BKZReduction<ZT, FT>::set_status(int new_status)
 {
   status = new_status;
   if (param.flags & BKZ_VERBOSE)
@@ -705,8 +705,8 @@ template <class FT> bool BKZReduction<FT>::set_status(int new_status)
   return status == RED_SUCCESS;
 }
 
-template <class FT>
-void BKZReduction<FT>::dump_gso(const std::string &filename, const std::string &prefix, bool append)
+template <class ZT, class FT>
+void BKZReduction<ZT, FT>::dump_gso(const std::string &filename, const std::string &prefix, bool append)
 {
   ofstream dump;
   if (append)
@@ -727,7 +727,7 @@ void BKZReduction<FT>::dump_gso(const std::string &filename, const std::string &
   dump.close();
 }
 
-template <class FT> bool BKZAutoAbort<FT>::test_abort(double scale, int maxNoDec)
+template <class ZT, class FT> bool BKZAutoAbort<ZT, FT>::test_abort(double scale, int maxNoDec)
 {
   double new_slope = -m.get_current_slope(start_row, num_rows);
   if (no_dec == -1 || new_slope < scale * old_slope)
@@ -753,7 +753,7 @@ int bkz_reduction_f(IntMatrix &b, const BKZParam &param, int sel_ft, double lll_
     gso_flags |= GSO_ROW_EXPO;
   MatGSO<Integer, FT> m_gso(b, u, u_inv, gso_flags);
   LLLReduction<Integer, FT> lll_obj(m_gso, lll_delta, LLL_DEF_ETA, LLL_DEFAULT);
-  BKZReduction<FT> bkz_obj(m_gso, lll_obj, param);
+  BKZReduction<Integer, FT> bkz_obj(m_gso, lll_obj, param);
   bkz_obj.bkz();
   return bkz_obj.status;
 }
@@ -866,28 +866,28 @@ int hkz_reduction(IntMatrix &b, int flags, FloatType float_type, int precision)
 
 /** enforce instantiation of complete templates **/
 
-template class BKZReduction<FP_NR<double>>;
-template class BKZAutoAbort<FP_NR<double>>;
+template class BKZReduction<Integer, FP_NR<double>>;
+template class BKZAutoAbort<Integer, FP_NR<double>>;
 
 #ifdef FPLLL_WITH_LONG_DOUBLE
-template class BKZReduction<FP_NR<long double>>;
-template class BKZAutoAbort<FP_NR<long double>>;
+template class BKZReduction<Integer, FP_NR<long double>>;
+template class BKZAutoAbort<Integer, FP_NR<long double>>;
 #endif
 
 #ifdef FPLLL_WITH_DPE
-template class BKZReduction<FP_NR<dpe_t>>;
-template class BKZAutoAbort<FP_NR<dpe_t>>;
+template class BKZReduction<Integer, FP_NR<dpe_t>>;
+template class BKZAutoAbort<Integer, FP_NR<dpe_t>>;
 #endif
 
 #ifdef FPLLL_WITH_QD
-template class BKZReduction<FP_NR<dd_real>>;
-template class BKZAutoAbort<FP_NR<dd_real>>;
+template class BKZReduction<Integer, FP_NR<dd_real>>;
+template class BKZAutoAbort<Integer, FP_NR<dd_real>>;
 
-template class BKZReduction<FP_NR<qd_real>>;
-template class BKZAutoAbort<FP_NR<qd_real>>;
+template class BKZReduction<Integer, FP_NR<qd_real>>;
+template class BKZAutoAbort<Integer, FP_NR<qd_real>>;
 #endif
 
-template class BKZReduction<FP_NR<mpfr_t>>;
-template class BKZAutoAbort<FP_NR<mpfr_t>>;
+template class BKZReduction<Integer, FP_NR<mpfr_t>>;
+template class BKZAutoAbort<Integer, FP_NR<mpfr_t>>;
 
 FPLLL_END_NAMESPACE

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -755,21 +755,21 @@ int bkz_reduction_f(IntMatrix &b, const BKZParam &param, int sel_ft, double lll_
     gso_flags |= GSO_ROW_EXPO;
 
   ZZ_mat<long> bl;
-  if (convert<IntegerT, long>(b, bl, 10))
+  if (convert<long, mpz_t>(bl, b, 10))
   {
     ZZ_mat<long> ul;
-    convert<IntegerT, long>(u, ul, 0);
+    convert<long, mpz_t>(ul, u, 0);
     ZZ_mat<long> ul_inv;
-    convert<IntegerT, long>(u_inv, ul_inv, 0);
+    convert<long, mpz_t>(ul_inv, u_inv, 0);
 
     MatGSO<Z_NR<long>, FT> m_gso(bl, ul, ul_inv, gso_flags);
     LLLReduction<Z_NR<long>, FT> lll_obj(m_gso, lll_delta, LLL_DEF_ETA, LLL_DEFAULT);
     BKZReduction<Z_NR<long>, FT> bkz_obj(m_gso, lll_obj, param);
     bkz_obj.bkz();
 
-    convert<long, IntegerT>(bl, b, 0);
-    convert<long, IntegerT>(ul, u, 0);
-    convert<long, IntegerT>(ul_inv, u_inv, 0);
+    convert<mpz_t, long>(b, bl, 0);
+    convert<mpz_t, long>(u, ul, 0);
+    convert<mpz_t, long>(u_inv, ul_inv, 0);
     return bkz_obj.status;
   }
   else

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -373,7 +373,6 @@ bool BKZReduction<ZT, FT>::trunc_tour(int &kappa_max, const BKZParam &par, int m
   int block_size = par.block_size;
   for (int kappa = min_row; kappa < max_row - block_size; ++kappa)
   {
-    //~ cerr << "kappa: " << kappa << endl;
     clean &= svp_reduction(kappa, block_size, par);
     if ((par.flags & BKZ_VERBOSE) && kappa_max < kappa && clean)
     {
@@ -406,7 +405,6 @@ bool BKZReduction<ZT, FT>::hkz(int &kappa_max, const BKZParam &param, int min_ro
   bool clean = true;
   for (int kappa = min_row; kappa < max_row - 1; ++kappa)
   {
-    //~ cerr << "kappa: " << kappa << endl;
     int block_size = max_row - kappa;
     clean &= svp_reduction(kappa, block_size, param);
     if ((param.flags & BKZ_VERBOSE) && kappa_max < kappa && clean)

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -105,12 +105,9 @@ bool BKZReduction<ZT, FT>::svp_preprocessing(int kappa, int block_size, const BK
   FPLLL_DEBUG_CHECK(param.strategies.size() > block_size);
 
   int lll_start = (param.flags & BKZ_BOUNDED_LLL) ? kappa : 0;
-  if (!lll_obj.lll(lll_start, lll_start, kappa + block_size, lll_start))
+  if (!lll_obj.lll(lll_start, lll_start, kappa + block_size, 0))
   {
-    if (!lll_obj.lll(lll_start, lll_start, kappa + block_size, 0))
-    {
-      throw std::runtime_error(RED_STATUS_STR[lll_obj.status]);
-    }
+    throw std::runtime_error(RED_STATUS_STR[lll_obj.status]);
   }
   if (lll_obj.n_swaps > 0)
     clean = false;
@@ -119,7 +116,7 @@ bool BKZReduction<ZT, FT>::svp_preprocessing(int kappa, int block_size, const BK
   for (auto it = preproc.begin(); it != preproc.end(); ++it)
   {
     int dummy_kappa_max = num_rows;
-    BKZParam prepar = BKZParam(*it, param.strategies, LLL_DEF_DELTA, BKZ_GH_BND | BKZ_BOUNDED_LLL);
+    BKZParam prepar = BKZParam(*it, param.strategies, LLL_DEF_DELTA, BKZ_GH_BND);
     clean &= tour(0, dummy_kappa_max, prepar, kappa, kappa + block_size);
   }
 

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -374,6 +374,7 @@ bool BKZReduction<ZT, FT>::trunc_tour(int &kappa_max, const BKZParam &par, int m
   int block_size = par.block_size;
   for (int kappa = min_row; kappa < max_row - block_size; ++kappa)
   {
+    //~ cerr << "kappa: " << kappa << endl;
     clean &= svp_reduction(kappa, block_size, par);
     if ((par.flags & BKZ_VERBOSE) && kappa_max < kappa && clean)
     {
@@ -406,6 +407,7 @@ bool BKZReduction<ZT, FT>::hkz(int &kappa_max, const BKZParam &param, int min_ro
   bool clean = true;
   for (int kappa = min_row; kappa < max_row - 1; ++kappa)
   {
+    //~ cerr << "kappa: " << kappa << endl;
     int block_size = max_row - kappa;
     clean &= svp_reduction(kappa, block_size, param);
     if ((param.flags & BKZ_VERBOSE) && kappa_max < kappa && clean)
@@ -751,11 +753,29 @@ int bkz_reduction_f(IntMatrix &b, const BKZParam &param, int sel_ft, double lll_
     return RED_SUCCESS;
   if (sel_ft == FT_DOUBLE || sel_ft == FT_LONG_DOUBLE)
     gso_flags |= GSO_ROW_EXPO;
-  MatGSO<Integer, FT> m_gso(b, u, u_inv, gso_flags);
-  LLLReduction<Integer, FT> lll_obj(m_gso, lll_delta, LLL_DEF_ETA, LLL_DEFAULT);
-  BKZReduction<Integer, FT> bkz_obj(m_gso, lll_obj, param);
-  bkz_obj.bkz();
-  return bkz_obj.status;
+  
+  ZZ_mat<long> bl;
+  if (convert<IntegerT, long>(b, bl, 10)) {
+    ZZ_mat<long> ul; convert<IntegerT, long>(u, ul, 0);
+    ZZ_mat<long> ul_inv; convert<IntegerT, long>(u_inv, ul_inv, 0);
+    
+    MatGSO<Z_NR<long>, FT> m_gso(bl, ul, ul_inv, gso_flags);
+    LLLReduction<Z_NR<long>, FT> lll_obj(m_gso, lll_delta, LLL_DEF_ETA, LLL_DEFAULT);
+    BKZReduction<Z_NR<long>, FT> bkz_obj(m_gso, lll_obj, param);
+    bkz_obj.bkz();
+    
+    convert<long, IntegerT>(bl, b, 0);
+    convert<long, IntegerT>(ul, u, 0);
+    convert<long, IntegerT>(ul_inv, u_inv, 0);
+    return bkz_obj.status;
+  } else {
+    MatGSO<Integer, FT> m_gso(b, u, u_inv, gso_flags);
+    LLLReduction<Integer, FT> lll_obj(m_gso, lll_delta, LLL_DEF_ETA, LLL_DEFAULT);
+    BKZReduction<Integer, FT> bkz_obj(m_gso, lll_obj, param);
+    bkz_obj.bkz();
+    return bkz_obj.status;
+  }
+  
 }
 
 /**
@@ -869,14 +889,23 @@ int hkz_reduction(IntMatrix &b, int flags, FloatType float_type, int precision)
 template class BKZReduction<Integer, FP_NR<double>>;
 template class BKZAutoAbort<Integer, FP_NR<double>>;
 
+template class BKZReduction<Z_NR<long>, FP_NR<double>>;
+template class BKZAutoAbort<Z_NR<long>, FP_NR<double>>;
+
 #ifdef FPLLL_WITH_LONG_DOUBLE
 template class BKZReduction<Integer, FP_NR<long double>>;
 template class BKZAutoAbort<Integer, FP_NR<long double>>;
+
+template class BKZReduction<Z_NR<long>, FP_NR<long double>>;
+template class BKZAutoAbort<Z_NR<long>, FP_NR<long double>>;
 #endif
 
 #ifdef FPLLL_WITH_DPE
 template class BKZReduction<Integer, FP_NR<dpe_t>>;
 template class BKZAutoAbort<Integer, FP_NR<dpe_t>>;
+
+template class BKZReduction<Z_NR<long>, FP_NR<dpe_t>>;
+template class BKZAutoAbort<Z_NR<long>, FP_NR<dpe_t>>;
 #endif
 
 #ifdef FPLLL_WITH_QD
@@ -885,9 +914,18 @@ template class BKZAutoAbort<Integer, FP_NR<dd_real>>;
 
 template class BKZReduction<Integer, FP_NR<qd_real>>;
 template class BKZAutoAbort<Integer, FP_NR<qd_real>>;
+
+template class BKZReduction<Z_NR<long>, FP_NR<dd_real>>;
+template class BKZAutoAbort<Z_NR<long>, FP_NR<dd_real>>;
+
+template class BKZReduction<Z_NR<long>, FP_NR<qd_real>>;
+template class BKZAutoAbort<Z_NR<long>, FP_NR<qd_real>>;
 #endif
 
 template class BKZReduction<Integer, FP_NR<mpfr_t>>;
 template class BKZAutoAbort<Integer, FP_NR<mpfr_t>>;
+
+template class BKZReduction<Z_NR<long>, FP_NR<mpfr_t>>;
+template class BKZAutoAbort<Z_NR<long>, FP_NR<mpfr_t>>;
 
 FPLLL_END_NAMESPACE

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -28,7 +28,7 @@ FPLLL_BEGIN_NAMESPACE
 
 template <class ZT, class FT>
 BKZReduction<ZT, FT>::BKZReduction(MatGSO<ZT, FT> &m, LLLReduction<ZT, FT> &lll_obj,
-                               const BKZParam &param)
+                                   const BKZParam &param)
     : status(RED_SUCCESS), nodes(0), param(param), m(m), lll_obj(lll_obj), algorithm(NULL),
       cputime_start(0)
 {
@@ -40,7 +40,8 @@ BKZReduction<ZT, FT>::BKZReduction(MatGSO<ZT, FT> &m, LLLReduction<ZT, FT> &lll_
 
 template <class ZT, class FT> BKZReduction<ZT, FT>::~BKZReduction() {}
 
-template <class ZT, class FT> void BKZReduction<ZT, FT>::rerandomize_block(int min_row, int max_row, int density)
+template <class ZT, class FT>
+void BKZReduction<ZT, FT>::rerandomize_block(int min_row, int max_row, int density)
 {
   if (max_row - min_row < 2)
     return;
@@ -79,7 +80,8 @@ template <class ZT, class FT> void BKZReduction<ZT, FT>::rerandomize_block(int m
 }
 
 template <class ZT, class FT>
-const Pruning &BKZReduction<ZT, FT>::get_pruning(int kappa, int block_size, const BKZParam &par) const
+const Pruning &BKZReduction<ZT, FT>::get_pruning(int kappa, int block_size,
+                                                 const BKZParam &par) const
 {
 
   FPLLL_DEBUG_CHECK(param.strategies.size() > block_size);
@@ -107,7 +109,7 @@ bool BKZReduction<ZT, FT>::svp_preprocessing(int kappa, int block_size, const BK
   {
     if (!lll_obj.lll(lll_start, lll_start, kappa + block_size, 0))
     {
-      throw std::runtime_error(RED_STATUS_STR[lll_obj.status]);      
+      throw std::runtime_error(RED_STATUS_STR[lll_obj.status]);
     }
   }
   if (lll_obj.n_swaps > 0)
@@ -117,7 +119,7 @@ bool BKZReduction<ZT, FT>::svp_preprocessing(int kappa, int block_size, const BK
   for (auto it = preproc.begin(); it != preproc.end(); ++it)
   {
     int dummy_kappa_max = num_rows;
-    BKZParam prepar     = BKZParam(*it, param.strategies, LLL_DEF_DELTA, BKZ_GH_BND | BKZ_BOUNDED_LLL);
+    BKZParam prepar = BKZParam(*it, param.strategies, LLL_DEF_DELTA, BKZ_GH_BND | BKZ_BOUNDED_LLL);
     clean &= tour(0, dummy_kappa_max, prepar, kappa, kappa + block_size);
   }
 
@@ -126,7 +128,7 @@ bool BKZReduction<ZT, FT>::svp_preprocessing(int kappa, int block_size, const BK
 
 template <class ZT, class FT>
 bool BKZReduction<ZT, FT>::svp_postprocessing(int kappa, int block_size, const vector<FT> &solution,
-                                          bool dual)
+                                              bool dual)
 {
   // Is it already in the basis ?
   int nz_vectors = 0, i_vector = -1;
@@ -201,7 +203,7 @@ bool BKZReduction<ZT, FT>::svp_postprocessing(int kappa, int block_size, const v
 
 template <class ZT, class FT>
 bool BKZReduction<ZT, FT>::svp_postprocessing_generic(int kappa, int block_size,
-                                                  const vector<FT> &solution, bool dual)
+                                                      const vector<FT> &solution, bool dual)
 {
   vector<FT> x = solution;
   int d        = block_size;
@@ -344,7 +346,7 @@ bool BKZReduction<ZT, FT>::svp_reduction(int kappa, int block_size, const BKZPar
 
 template <class ZT, class FT>
 bool BKZReduction<ZT, FT>::tour(const int loop, int &kappa_max, const BKZParam &par, int min_row,
-                            int max_row)
+                                int max_row)
 {
   bool clean = true;
   clean &= trunc_tour(kappa_max, par, min_row, max_row);
@@ -657,7 +659,8 @@ template <class ZT, class FT> bool BKZReduction<ZT, FT>::bkz()
   return set_status(final_status);
 }
 
-template <class ZT, class FT> void BKZReduction<ZT, FT>::print_tour(const int loop, int min_row, int max_row)
+template <class ZT, class FT>
+void BKZReduction<ZT, FT>::print_tour(const int loop, int min_row, int max_row)
 {
   FT r0;
   Float fr0;
@@ -673,7 +676,8 @@ template <class ZT, class FT> void BKZReduction<ZT, FT>::print_tour(const int lo
   cerr << ", log2(nodes) = " << std::setw(9) << std::setprecision(6) << log2(nodes) << endl;
 }
 
-template <class ZT, class FT> void BKZReduction<ZT, FT>::print_params(const BKZParam &param, ostream &out)
+template <class ZT, class FT>
+void BKZReduction<ZT, FT>::print_params(const BKZParam &param, ostream &out)
 {
   out << "block size: " << std::setw(3) << param.block_size << ", ";
   out << "flags: 0x" << std::setw(4) << setfill('0') << std::hex << param.flags << ", " << std::dec
@@ -708,7 +712,8 @@ template <class ZT, class FT> bool BKZReduction<ZT, FT>::set_status(int new_stat
 }
 
 template <class ZT, class FT>
-void BKZReduction<ZT, FT>::dump_gso(const std::string &filename, const std::string &prefix, bool append)
+void BKZReduction<ZT, FT>::dump_gso(const std::string &filename, const std::string &prefix,
+                                    bool append)
 {
   ofstream dump;
   if (append)
@@ -753,29 +758,33 @@ int bkz_reduction_f(IntMatrix &b, const BKZParam &param, int sel_ft, double lll_
     return RED_SUCCESS;
   if (sel_ft == FT_DOUBLE || sel_ft == FT_LONG_DOUBLE)
     gso_flags |= GSO_ROW_EXPO;
-  
+
   ZZ_mat<long> bl;
-  if (convert<IntegerT, long>(b, bl, 10)) {
-    ZZ_mat<long> ul; convert<IntegerT, long>(u, ul, 0);
-    ZZ_mat<long> ul_inv; convert<IntegerT, long>(u_inv, ul_inv, 0);
-    
+  if (convert<IntegerT, long>(b, bl, 10))
+  {
+    ZZ_mat<long> ul;
+    convert<IntegerT, long>(u, ul, 0);
+    ZZ_mat<long> ul_inv;
+    convert<IntegerT, long>(u_inv, ul_inv, 0);
+
     MatGSO<Z_NR<long>, FT> m_gso(bl, ul, ul_inv, gso_flags);
     LLLReduction<Z_NR<long>, FT> lll_obj(m_gso, lll_delta, LLL_DEF_ETA, LLL_DEFAULT);
     BKZReduction<Z_NR<long>, FT> bkz_obj(m_gso, lll_obj, param);
     bkz_obj.bkz();
-    
+
     convert<long, IntegerT>(bl, b, 0);
     convert<long, IntegerT>(ul, u, 0);
     convert<long, IntegerT>(ul_inv, u_inv, 0);
     return bkz_obj.status;
-  } else {
+  }
+  else
+  {
     MatGSO<Integer, FT> m_gso(b, u, u_inv, gso_flags);
     LLLReduction<Integer, FT> lll_obj(m_gso, lll_delta, LLL_DEF_ETA, LLL_DEFAULT);
     BKZReduction<Integer, FT> bkz_obj(m_gso, lll_obj, param);
     bkz_obj.bkz();
     return bkz_obj.status;
   }
-  
 }
 
 /**

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -103,9 +103,12 @@ bool BKZReduction<FT>::svp_preprocessing(int kappa, int block_size, const BKZPar
   FPLLL_DEBUG_CHECK(param.strategies.size() > block_size);
 
   int lll_start = (param.flags & BKZ_BOUNDED_LLL) ? kappa : 0;
-  if (!lll_obj.lll(lll_start, lll_start, kappa + block_size, 0))
+  if (!lll_obj.lll(lll_start, lll_start, kappa + block_size, lll_start))
   {
-    throw std::runtime_error(RED_STATUS_STR[lll_obj.status]);
+    if (!lll_obj.lll(lll_start, lll_start, kappa + block_size, 0))
+    {
+      throw std::runtime_error(RED_STATUS_STR[lll_obj.status]);      
+    }
   }
   if (lll_obj.n_swaps > 0)
     clean = false;
@@ -114,7 +117,7 @@ bool BKZReduction<FT>::svp_preprocessing(int kappa, int block_size, const BKZPar
   for (auto it = preproc.begin(); it != preproc.end(); ++it)
   {
     int dummy_kappa_max = num_rows;
-    BKZParam prepar     = BKZParam(*it, param.strategies, LLL_DEF_DELTA, BKZ_GH_BND);
+    BKZParam prepar     = BKZParam(*it, param.strategies, LLL_DEF_DELTA, BKZ_GH_BND | BKZ_BOUNDED_LLL);
     clean &= tour(0, dummy_kappa_max, prepar, kappa, kappa + block_size);
   }
 

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -116,7 +116,7 @@ bool BKZReduction<ZT, FT>::svp_preprocessing(int kappa, int block_size, const BK
   for (auto it = preproc.begin(); it != preproc.end(); ++it)
   {
     int dummy_kappa_max = num_rows;
-    BKZParam prepar = BKZParam(*it, param.strategies, LLL_DEF_DELTA, BKZ_GH_BND);
+    BKZParam prepar     = BKZParam(*it, param.strategies, LLL_DEF_DELTA, BKZ_GH_BND);
     clean &= tour(0, dummy_kappa_max, prepar, kappa, kappa + block_size);
   }
 

--- a/fplll/bkz.h
+++ b/fplll/bkz.h
@@ -25,7 +25,7 @@
 
 FPLLL_BEGIN_NAMESPACE
 
-template <class FT> class BKZAutoAbort
+template <class ZT, class FT> class BKZAutoAbort
 {
 public:
   /**
@@ -37,7 +37,7 @@ public:
      @return
   */
 
-  BKZAutoAbort(MatGSO<Integer, FT> &m, int num_rows, int start_row = 0)
+  BKZAutoAbort(MatGSO<ZT, FT> &m, int num_rows, int start_row = 0)
       : m(m), old_slope(numeric_limits<double>::max()), no_dec(-1), num_rows(num_rows),
         start_row(start_row)
   {
@@ -45,7 +45,7 @@ public:
   bool test_abort(double scale = 1.0, int maxNoDec = 5);
 
 private:
-  MatGSO<Integer, FT> &m;
+  MatGSO<ZT, FT> &m;
   double old_slope;
   int no_dec;
   int num_rows;
@@ -53,10 +53,10 @@ private:
 };
 
 /* The matrix must be LLL-reduced */
-template <class FT> class BKZReduction
+template <class ZT, class FT> class BKZReduction
 {
 public:
-  BKZReduction(MatGSO<Integer, FT> &m, LLLReduction<Integer, FT> &lll_obj, const BKZParam &param);
+  BKZReduction(MatGSO<ZT, FT> &m, LLLReduction<ZT, FT> &lll_obj, const BKZParam &param);
   ~BKZReduction();
 
   bool svp_preprocessing(int kappa, int block_size, const BKZParam &param);
@@ -195,8 +195,8 @@ private:
 
   const BKZParam &param;
   int num_rows;
-  MatGSO<Integer, FT> &m;
-  LLLReduction<Integer, FT> &lll_obj;
+  MatGSO<ZT, FT> &m;
+  LLLReduction<ZT, FT> &lll_obj;
   FastEvaluator<FT> evaluator;
   FT delta;
 

--- a/fplll/nr/matrix.cpp
+++ b/fplll/nr/matrix.cpp
@@ -606,7 +606,9 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_trg2(FP_NR<mpfr_t> *w)
   }
 }
 
-template <class ZTfrom, class ZTto> bool convert(const ZZ_mat<ZTfrom> &Afrom, ZZ_mat<ZTto> &Ato, int buffer) {
+template <class ZTfrom, class ZTto>
+bool convert(const ZZ_mat<ZTfrom> &Afrom, ZZ_mat<ZTto> &Ato, int buffer)
+{
   Ato.clear();
   int r = Afrom.get_rows();
   int c = Afrom.get_cols();
@@ -614,16 +616,19 @@ template <class ZTfrom, class ZTto> bool convert(const ZZ_mat<ZTfrom> &Afrom, ZZ
   long threshold = (1L << (numeric_limits<long>::digits - buffer - 1));
   //~ cerr << "Threshold = " << threshold << endl;
   Z_NR<ZTfrom> ztmp;
-  for (int i = 0; i < r; ++i) {
-    for (int j = 0 ; j < c; ++j) {
+  for (int i = 0; i < r; ++i)
+  {
+    for (int j = 0; j < c; ++j)
+    {
       ztmp.abs(Afrom[i][j]);
-      if (ztmp > threshold) {
+      if (ztmp > threshold)
+      {
         return false;
       }
       Ato[i][j] = Afrom[i][j].get_si();
     }
   }
-  
+
   return true;
 }
 

--- a/fplll/nr/matrix.cpp
+++ b/fplll/nr/matrix.cpp
@@ -614,7 +614,6 @@ bool convert(const ZZ_mat<ZTfrom> &Afrom, ZZ_mat<ZTto> &Ato, int buffer)
   int c = Afrom.get_cols();
   Ato.resize(r, c);
   long threshold = (1L << (numeric_limits<long>::digits - buffer - 1));
-  //~ cerr << "Threshold = " << threshold << endl;
   Z_NR<ZTfrom> ztmp;
   for (int i = 0; i < r; ++i)
   {

--- a/fplll/nr/matrix.cpp
+++ b/fplll/nr/matrix.cpp
@@ -606,8 +606,8 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_trg2(FP_NR<mpfr_t> *w)
   }
 }
 
-template <class ZTfrom, class ZTto>
-bool convert(const ZZ_mat<ZTfrom> &Afrom, ZZ_mat<ZTto> &Ato, int buffer)
+template <class ZTto, class ZTfrom>
+bool convert(ZZ_mat<ZTto> &Ato, const ZZ_mat<ZTfrom> &Afrom, int buffer)
 {
   Ato.clear();
   int r = Afrom.get_rows();

--- a/fplll/nr/matrix.cpp
+++ b/fplll/nr/matrix.cpp
@@ -606,6 +606,27 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_trg2(FP_NR<mpfr_t> *w)
   }
 }
 
+template <class ZTfrom, class ZTto> bool convert(const ZZ_mat<ZTfrom> &Afrom, ZZ_mat<ZTto> &Ato, int buffer) {
+  Ato.clear();
+  int r = Afrom.get_rows();
+  int c = Afrom.get_cols();
+  Ato.resize(r, c);
+  long threshold = (1L << (numeric_limits<long>::digits - buffer - 1));
+  //~ cerr << "Threshold = " << threshold << endl;
+  Z_NR<ZTfrom> ztmp;
+  for (int i = 0; i < r; ++i) {
+    for (int j = 0 ; j < c; ++j) {
+      ztmp.abs(Afrom[i][j]);
+      if (ztmp > threshold) {
+        return false;
+      }
+      Ato[i][j] = Afrom[i][j].get_si();
+    }
+  }
+  
+  return true;
+}
+
 FPLLL_END_NAMESPACE
 
 #endif

--- a/fplll/nr/matrix.h
+++ b/fplll/nr/matrix.h
@@ -322,13 +322,14 @@ and random sub-diagonal coefficients.
 };
 
 /**
- * Converts integer matrices. Conversion is coing through get_si(), so ONLY use for 
- * small numbers that fit into longs. More specifically, Afrom is converted to Ato 
- * (and true is returned) if all numbers in Afrom fit into 
- * numeric_limits<long>::digits - buffer bits. Otherwise, conversion is aborted and 
+ * Converts integer matrices. Conversion is coing through get_si(), so ONLY use for
+ * small numbers that fit into longs. More specifically, Afrom is converted to Ato
+ * (and true is returned) if all numbers in Afrom fit into
+ * numeric_limits<long>::digits - buffer bits. Otherwise, conversion is aborted and
  * false is returned.
  */
-template <class ZTfrom, class ZTto> bool convert(const ZZ_mat<ZTfrom> &Afrom, ZZ_mat<ZTto> &Ato, int buffer = 0);
+template <class ZTfrom, class ZTto>
+bool convert(const ZZ_mat<ZTfrom> &Afrom, ZZ_mat<ZTto> &Ato, int buffer = 0);
 
 /** FP_mat is a matrix of floating-point numbers. */
 template <class FT> class FP_mat : public Matrix<FP_NR<FT>>

--- a/fplll/nr/matrix.h
+++ b/fplll/nr/matrix.h
@@ -328,8 +328,8 @@ and random sub-diagonal coefficients.
  * numeric_limits<long>::digits - buffer bits. Otherwise, conversion is aborted and
  * false is returned.
  */
-template <class ZTfrom, class ZTto>
-bool convert(const ZZ_mat<ZTfrom> &Afrom, ZZ_mat<ZTto> &Ato, int buffer = 0);
+template <class ZTto, class ZTfrom>
+bool convert(ZZ_mat<ZTto> &Ato, const ZZ_mat<ZTfrom> &Afrom, int buffer = 0);
 
 /** FP_mat is a matrix of floating-point numbers. */
 template <class FT> class FP_mat : public Matrix<FP_NR<FT>>

--- a/fplll/nr/matrix.h
+++ b/fplll/nr/matrix.h
@@ -321,6 +321,15 @@ and random sub-diagonal coefficients.
   void gen_trg2(FP_NR<mpfr_t> *w);
 };
 
+/**
+ * Converts integer matrices. Conversion is coing through get_si(), so ONLY use for 
+ * small numbers that fit into longs. More specifically, Afrom is converted to Ato 
+ * (and true is returned) if all numbers in Afrom fit into 
+ * numeric_limits<long>::digits - buffer bits. Otherwise, conversion is aborted and 
+ * false is returned.
+ */
+template <class ZTfrom, class ZTto> bool convert(const ZZ_mat<ZTfrom> &Afrom, ZZ_mat<ZTto> &Ato, int buffer = 0);
+
 /** FP_mat is a matrix of floating-point numbers. */
 template <class FT> class FP_mat : public Matrix<FP_NR<FT>>
 {

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -253,7 +253,7 @@ template <class ZT> int test_dsvp_reduce(ZZ_mat<ZT> &A, IntVect &b)
 
   vector<Strategy> strategies;
   BKZParam dummy(d, strategies);
-  BKZReduction<Float> bkz_obj(gso, lll_obj, dummy);
+  BKZReduction<Integer, Float> bkz_obj(gso, lll_obj, dummy);
   bool clean = true;
 
   bkz_obj.svp_reduction_ex(0, d, dummy, clean, true);


### PR DESCRIPTION
bkz reduction runs with long integers instead of mpz, if the numbers in the basis are small enough. the bkz reduction is templated with an integer type, the switch happens in the bkz_reduction_f function, so the user interface (bkz_reduction(...)) did not change.