### PR TITLE
Make distcheck for test_bkz

### DIFF
--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -23,11 +23,18 @@
 using namespace std;
 using namespace fplll;
 
-template <class ZT> void read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
+template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {
   istream *is = new ifstream(input_filename);
   *is >> A;
+  int status = 0;
+  if (A.empty())
+  {
+    status = 1;
+    cerr << "File " << input_filename << " was (probably) not opened." << endl;
+  }
   delete is;
+  return status;
 }
 
 /**
@@ -187,9 +194,9 @@ int test_filename(const char *input_filename, const int block_size,
                   FloatType float_type = FT_DEFAULT, int flags = BKZ_DEFAULT, int prec = 0)
 {
   ZZ_mat<ZT> A, B;
-  read_matrix(A, input_filename);
-  B          = A;
   int status = 0;
+  status |= read_matrix(A, input_filename);
+  B = A;
   status |= test_bkz<ZT>(A, block_size, float_type, flags, prec);
   status |= test_bkz_param<ZT>(B, block_size);
   return status;

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -244,16 +244,20 @@ int main(int /*argc*/, char ** /*argv*/)
   int status = 0;
 
   status |= test_linear_dep();
-  status |= test_filename<mpz_t>("lattices/dim55_in", 10, FT_DEFAULT, BKZ_DEFAULT | BKZ_AUTO_ABORT);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/dim55_in", 10, FT_DEFAULT,
+                                 BKZ_DEFAULT | BKZ_AUTO_ABORT);
 #ifdef FPLLL_HAVE_QD
-  status |= test_filename<mpz_t>("lattices/dim55_in", 10, FT_DD, BKZ_SD_VARIANT | BKZ_AUTO_ABORT);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/dim55_in", 10, FT_DD,
+                                 BKZ_SD_VARIANT | BKZ_AUTO_ABORT);
 #endif
-  status |= test_filename<mpz_t>("lattices/dim55_in", 10, FT_DEFAULT, BKZ_SLD_RED);
   status |=
-      test_filename<mpz_t>("lattices/dim55_in", 20, FT_MPFR, BKZ_DEFAULT | BKZ_AUTO_ABORT, 128);
+      test_filename<mpz_t>(TESTDATADIR "/tests/lattices/dim55_in", 10, FT_DEFAULT, BKZ_SLD_RED);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/dim55_in", 20, FT_MPFR,
+                                 BKZ_DEFAULT | BKZ_AUTO_ABORT, 128);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/dim55_in", 20, FT_MPFR,
+                                 BKZ_SD_VARIANT | BKZ_AUTO_ABORT, 128);
   status |=
-      test_filename<mpz_t>("lattices/dim55_in", 20, FT_MPFR, BKZ_SD_VARIANT | BKZ_AUTO_ABORT, 128);
-  status |= test_filename<mpz_t>("lattices/dim55_in", 20, FT_MPFR, BKZ_SLD_RED, 128);
+      test_filename<mpz_t>(TESTDATADIR "/tests/lattices/dim55_in", 20, FT_MPFR, BKZ_SLD_RED, 128);
 
   status |= test_int_rel<mpz_t>(50, 1000, 10, FT_DOUBLE, BKZ_DEFAULT | BKZ_AUTO_ABORT);
   status |= test_int_rel<mpz_t>(50, 1000, 10, FT_DOUBLE, BKZ_SD_VARIANT | BKZ_AUTO_ABORT);
@@ -269,20 +273,27 @@ int main(int /*argc*/, char ** /*argv*/)
   status |= test_int_rel<mpz_t>(30, 2000, 10, FT_MPFR, BKZ_SD_VARIANT | BKZ_AUTO_ABORT, 53);
   status |= test_int_rel<mpz_t>(30, 2000, 10, FT_MPFR, BKZ_SLD_RED, 53);
 
-  status |= test_filename<mpz_t>("lattices/example_in", 10);
-  status |= test_filename<mpz_t>("lattices/example_in", 10, FT_DEFAULT, BKZ_SD_VARIANT);
-  status |= test_filename<mpz_t>("lattices/example_in", 10, FT_DEFAULT, BKZ_SLD_RED);
-  status |= test_filename<mpz_t>("lattices/example_in", 10, FT_DOUBLE);
-  status |= test_filename<mpz_t>("lattices/example_in", 10, FT_DOUBLE, BKZ_SD_VARIANT);
-  status |= test_filename<mpz_t>("lattices/example_in", 10, FT_DOUBLE, BKZ_SLD_RED);
-  status |= test_filename<mpz_t>("lattices/example_in", 10, FT_MPFR, BKZ_AUTO_ABORT, 212);
-  status |= test_filename<mpz_t>("lattices/example_in", 10, FT_MPFR,
-                                 BKZ_SD_VARIANT | BKZ_AUTO_ABORT, 212);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_DEFAULT,
+                                 BKZ_SD_VARIANT);
   status |=
-      test_filename<mpz_t>("lattices/example_in", 10, FT_MPFR, BKZ_SLD_RED | BKZ_AUTO_ABORT, 212);
-  status |= test_filename<mpz_t>("lattices/example_in", 10, FT_DOUBLE);
-  status |= test_filename<mpz_t>("lattices/example_in", 10, FT_DOUBLE, BKZ_SD_VARIANT);
-  status |= test_filename<mpz_t>("lattices/example_in", 10, FT_DOUBLE, BKZ_SLD_RED);
+      test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_DEFAULT, BKZ_SLD_RED);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_DOUBLE);
+  status |=
+      test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_DOUBLE, BKZ_SD_VARIANT);
+  status |=
+      test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_DOUBLE, BKZ_SLD_RED);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_MPFR,
+                                 BKZ_AUTO_ABORT, 212);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_MPFR,
+                                 BKZ_SD_VARIANT | BKZ_AUTO_ABORT, 212);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_MPFR,
+                                 BKZ_SLD_RED | BKZ_AUTO_ABORT, 212);
+  status |= test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_DOUBLE);
+  status |=
+      test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_DOUBLE, BKZ_SD_VARIANT);
+  status |=
+      test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_DOUBLE, BKZ_SLD_RED);
 
   if (status == 0)
   {

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -23,6 +23,13 @@
 using namespace std;
 using namespace fplll;
 
+/**
+   @brief Read matrix from `input_filename`.
+
+   @param A
+   @param input_filename
+   @return zero if A is not empty.
+*/
 template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {
   istream *is = new ifstream(input_filename);

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -14,9 +14,9 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include "io/json.hpp"
+#include <../tests/test_utils.h>
 #include <cstring>
 #include <fplll.h>
-#include <test_utils.h>
 
 using json = nlohmann::json;
 

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -16,6 +16,7 @@
 #include "io/json.hpp"
 #include <cstring>
 #include <fplll.h>
+#include <test_utils.h>
 
 using json = nlohmann::json;
 
@@ -25,27 +26,6 @@ using json = nlohmann::json;
 
 using namespace std;
 using namespace fplll;
-
-/**
-   @brief Read matrix from `input_filename`.
-
-   @param A
-   @param input_filename
-   @return zero if A is not empty.
-*/
-template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
-{
-  istream *is = new ifstream(input_filename);
-  *is >> A;
-  int status = 0;
-  if (A.empty())
-  {
-    status = 1;
-    cerr << "File " << input_filename << " was (probably) not opened." << endl;
-  }
-  delete is;
-  return status;
-}
 
 /**
    @brief Test BKZ reduction.

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -30,11 +30,18 @@ using namespace fplll;
    @return
 */
 
-template <class ZT> void read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
+template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {
   istream *is = new ifstream(input_filename);
   *is >> A;
+  int status = 0;
+  if (A.empty())
+  {
+    status = 1;
+    cerr << "File " << input_filename << " was (probably) not opened." << endl;
+  }
   delete is;
+  return status;
 }
 
 /**
@@ -45,11 +52,18 @@ template <class ZT> void read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
    @return
 */
 
-template <class ZT> void read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
+template <class ZT> int read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
 {
   istream *is = new ifstream(input_filename);
   *is >> b;
+  int status = 0;
+  if (b.empty())
+  {
+    status = 1;
+    cerr << "File " << input_filename << " was (probably) not opened." << endl;
+  }
   delete is;
+  return status;
 }
 
 /**
@@ -116,15 +130,17 @@ int test_filename(const char *input_filename_lattice, const char *input_filename
                   const char *output_filename, const int method = CVPM_FAST)
 {
   ZZ_mat<ZT> A;
-  read_matrix(A, input_filename_lattice);
+  int status = 0;
+  status |= read_matrix(A, input_filename_lattice);
 
   IntVect t;
-  read_vector(t, input_filename_target);
+  status |= read_vector(t, input_filename_target);
 
   IntVect b;
-  read_vector(b, output_filename);
+  status |= read_vector(b, output_filename);
 
-  return test_cvp<ZT>(A, t, b, method);
+  status |= test_cvp<ZT>(A, t, b, method);
+  return status;
 }
 
 /**

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -13,9 +13,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include <../tests/test_utils.h>
 #include <cstring>
 #include <fplll.h>
-#include <test_utils.h>
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -27,7 +27,7 @@ using namespace fplll;
 
    @param A
    @param input_filename
-   @return
+   @return zero if A is not empty.
 */
 
 template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
@@ -49,7 +49,7 @@ template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 
    @param b                vector
    @param input_filename   filename
-   @return
+   @return zero if b is not empty.
 */
 
 template <class ZT> int read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -15,56 +15,13 @@
 
 #include <cstring>
 #include <fplll.h>
+#include <test_utils.h>
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."
 #endif
 using namespace std;
 using namespace fplll;
-
-/**
-   @brief Read matrix from `input_filename`.
-
-   @param A
-   @param input_filename
-   @return zero if A is not empty.
-*/
-
-template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
-{
-  istream *is = new ifstream(input_filename);
-  *is >> A;
-  int status = 0;
-  if (A.empty())
-  {
-    status = 1;
-    cerr << "File " << input_filename << " was (probably) not opened." << endl;
-  }
-  delete is;
-  return status;
-}
-
-/**
-   @brief Read vector from `input_filename` into `b`.
-
-   @param b                vector
-   @param input_filename   filename
-   @return zero if b is not empty.
-*/
-
-template <class ZT> int read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
-{
-  istream *is = new ifstream(input_filename);
-  *is >> b;
-  int status = 0;
-  if (b.empty())
-  {
-    status = 1;
-    cerr << "File " << input_filename << " was (probably) not opened." << endl;
-  }
-  delete is;
-  return status;
-}
 
 /**
    @brief Test if CVP function returns correct vector.

--- a/tests/test_gso.cpp
+++ b/tests/test_gso.cpp
@@ -19,6 +19,7 @@
 #include <gso_interface.h>
 #include <nr/matrix.h>
 //#include <random>
+#include <test_utils.h>
 
 using namespace std;
 using namespace fplll;
@@ -66,16 +67,6 @@ template <class ZT, class FT> bool rs_are_equal(MatGSO<ZT, FT> M1, MatGSOGram<ZT
     return false;
   }
   return true;
-}
-
-template <class ZT> void read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
-{
-  ifstream is(input_filename);
-  if (!is)
-  {
-    cerr << "Could not open file!" << endl;
-  }  // throw std::runtime_error("could not open input file");
-  is >> A;
 }
 
 template <class ZT, class FT> int test_ggso(ZZ_mat<ZT> &A)

--- a/tests/test_gso.cpp
+++ b/tests/test_gso.cpp
@@ -19,7 +19,7 @@
 #include <gso_interface.h>
 #include <nr/matrix.h>
 //#include <random>
-#include <test_utils.h>
+#include <../tests/test_utils.h>
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_gso.cpp
+++ b/tests/test_gso.cpp
@@ -151,7 +151,12 @@ template <class ZT, class FT> int test_ggso(ZZ_mat<ZT> &A)
 template <class ZT, class FT> int test_filename(const char *input_filename)
 {
   ZZ_mat<ZT> A;
-  read_matrix(A, input_filename);
+  int status = read_matrix(A, input_filename);
+  // if status == 1, read_matrix fails.
+  if (status == 1)
+  {
+    return 1;
+  }
   int retvalue = test_ggso<ZT, FT>(A);
   if (retvalue & 1)
   {

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -13,9 +13,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include <../tests/test_utils.h>
 #include <cstring>
 #include <fplll.h>
-#include <test_utils.h>
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -15,6 +15,7 @@
 
 #include <cstring>
 #include <fplll.h>
+#include <test_utils.h>
 
 using namespace std;
 using namespace fplll;
@@ -22,27 +23,6 @@ using namespace fplll;
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."
 #endif
-
-/**
-   @brief Read matrix from `input_filename`.
-
-   @param A
-   @param input_filename
-   @return zero if A is not empty.
-*/
-template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
-{
-  istream *is = new ifstream(input_filename);
-  *is >> A;
-  int status = 0;
-  if (A.empty())
-  {
-    status = 1;
-    cerr << "File " << input_filename << " was (probably) not opened." << endl;
-  }
-  delete is;
-  return status;
-}
 
 /**
    @brief Test the tester.

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -23,6 +23,13 @@ using namespace fplll;
 #define TESTDATADIR ".."
 #endif
 
+/**
+   @brief Read matrix from `input_filename`.
+
+   @param A
+   @param input_filename
+   @return zero if A is not empty.
+*/
 template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {
   istream *is = new ifstream(input_filename);

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -23,11 +23,18 @@ using namespace fplll;
 #define TESTDATADIR ".."
 #endif
 
-template <class ZT> void read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
+template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {
   istream *is = new ifstream(input_filename);
   *is >> A;
+  int status = 0;
+  if (A.empty())
+  {
+    status = 1;
+    cerr << "File " << input_filename << " was (probably) not opened." << endl;
+  }
   delete is;
+  return status;
 }
 
 /**
@@ -124,8 +131,10 @@ int test_filename(const char *input_filename, LLLMethod method, FloatType float_
                   int flags = LLL_DEFAULT, int prec = 0)
 {
   ZZ_mat<ZT> A;
-  read_matrix(A, input_filename);
-  return test_lll<ZT>(A, method, float_type, flags, prec);
+  int status = 0;
+  status |= read_matrix(A, input_filename);
+  status |= test_lll<ZT>(A, method, float_type, flags, prec);
+  return status;
 }
 
 /**

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -46,6 +46,13 @@ bool have_equal_grammatrix(MatGSO<Z_NR<ZT>, FP_NR<FT>> M1, MatGSOGram<Z_NR<ZT>, 
   return true;
 }
 
+/**
+   @brief Read matrix from `input_filename`.
+
+   @param A
+   @param input_filename
+   @return zero if A is not empty.
+*/
 template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {
   ifstream is(input_filename);

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -46,14 +46,17 @@ bool have_equal_grammatrix(MatGSO<Z_NR<ZT>, FP_NR<FT>> M1, MatGSOGram<Z_NR<ZT>, 
   return true;
 }
 
-template <class ZT> void read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
+template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {
   ifstream is(input_filename);
+  int status = 0;
   if (!is)
   {
+    status = 1;
     cerr << "Could not open file!" << endl;
   }  // throw std::runtime_error("could not open input file");
   is >> A;
+  return status;
 }
 
 template <class ZT, class FT> int is_already_reduced(ZZ_mat<ZT> &A, Matrix<Z_NR<ZT>> &G)
@@ -171,8 +174,10 @@ template <class ZT, class FT> int test_lll(ZZ_mat<ZT> &A)
 template <class ZT, class FT> int test_filename(const char *input_filename)
 {
   ZZ_mat<ZT> A;
-  read_matrix(A, input_filename);
-  return test_lll<ZT, FT>(A);
+  int status = 0;
+  status |= read_matrix(A, input_filename);
+  status |= test_lll<ZT, FT>(A);
+  return status;
 }
 
 /**

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -13,13 +13,13 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include <../tests/test_utils.h>
 #include <cstring>
 #include <fplll.h>
 #include <gso.h>
 #include <gso_gram.h>
 #include <gso_interface.h>
 #include <lll.h>
-#include <test_utils.h>
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -19,6 +19,7 @@
 #include <gso_gram.h>
 #include <gso_interface.h>
 #include <lll.h>
+#include <test_utils.h>
 
 using namespace std;
 using namespace fplll;
@@ -44,26 +45,6 @@ bool have_equal_grammatrix(MatGSO<Z_NR<ZT>, FP_NR<FT>> M1, MatGSOGram<Z_NR<ZT>, 
     }
   }
   return true;
-}
-
-/**
-   @brief Read matrix from `input_filename`.
-
-   @param A
-   @param input_filename
-   @return zero if A is not empty.
-*/
-template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
-{
-  ifstream is(input_filename);
-  int status = 0;
-  if (!is)
-  {
-    status = 1;
-    cerr << "Could not open file!" << endl;
-  }  // throw std::runtime_error("could not open input file");
-  is >> A;
-  return status;
 }
 
 template <class ZT, class FT> int is_already_reduced(ZZ_mat<ZT> &A, Matrix<Z_NR<ZT>> &G)

--- a/tests/test_sieve.cpp
+++ b/tests/test_sieve.cpp
@@ -16,11 +16,18 @@ using namespace fplll;
    @param input_filename
    @return
 */
-template <class ZT> void read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
+template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {
   istream *is = new ifstream(input_filename);
   *is >> A;
+  int status = 0;
+  if (A.empty())
+  {
+    status = 1;
+    cerr << "File " << input_filename << " was (probably) not opened." << endl;
+  }
   delete is;
+  return status;
 }
 
 /**
@@ -30,11 +37,18 @@ template <class ZT> void read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
    @param input_filename   filename
    @return
 */
-template <class ZT> void read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
+template <class ZT> int read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
 {
   istream *is = new ifstream(input_filename);
   *is >> b;
+  int status = 0;
+  if (b.empty())
+  {
+    status = 1;
+    cerr << "File " << input_filename << " was (probably) not opened." << endl;
+  }
   delete is;
+  return status;
 }
 
 /**
@@ -84,10 +98,12 @@ template <class ZT> int test_sieve(ZZ_mat<ZT> &A, IntVect &b)
 template <class ZT> int test_filename(const char *input_filename, const char *output_filename)
 {
   ZZ_mat<ZT> A;
-  read_matrix(A, input_filename);
+  int status = 0;
+  status |= read_matrix(A, input_filename);
   IntVect b;
-  read_vector(b, output_filename);
-  return test_sieve<ZT>(A, b);
+  status |= read_vector(b, output_filename);
+  status |= test_sieve<ZT>(A, b);
+  return status;
 }
 
 /*

--- a/tests/test_sieve.cpp
+++ b/tests/test_sieve.cpp
@@ -14,7 +14,7 @@ using namespace fplll;
 
    @param A
    @param input_filename
-   @return
+   @return zero if A is not empty.
 */
 template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {

--- a/tests/test_sieve.cpp
+++ b/tests/test_sieve.cpp
@@ -1,7 +1,7 @@
 #include <../fplll/sieve/sieve_main.h> /* standalone bin */
+#include <../tests/test_utils.h>
 #include <cstring>
 #include <fplll.h>
-#include <test_utils.h>
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_sieve.cpp
+++ b/tests/test_sieve.cpp
@@ -1,6 +1,7 @@
 #include <../fplll/sieve/sieve_main.h> /* standalone bin */
 #include <cstring>
 #include <fplll.h>
+#include <test_utils.h>
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."
@@ -8,48 +9,6 @@
 
 using namespace std;
 using namespace fplll;
-
-/**
-   @brief Read matrix from `input_filename`.
-
-   @param A
-   @param input_filename
-   @return zero if A is not empty.
-*/
-template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
-{
-  istream *is = new ifstream(input_filename);
-  *is >> A;
-  int status = 0;
-  if (A.empty())
-  {
-    status = 1;
-    cerr << "File " << input_filename << " was (probably) not opened." << endl;
-  }
-  delete is;
-  return status;
-}
-
-/**
-   @brief Read vector from `input_filename` into `b`.
-
-   @param b                vector
-   @param input_filename   filename
-   @return
-*/
-template <class ZT> int read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
-{
-  istream *is = new ifstream(input_filename);
-  *is >> b;
-  int status = 0;
-  if (b.empty())
-  {
-    status = 1;
-    cerr << "File " << input_filename << " was (probably) not opened." << endl;
-  }
-  delete is;
-  return status;
-}
 
 /**
    @brief Test sieve by checking if function returns correct vector.

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -39,11 +39,18 @@ enum Test
    @return
 */
 
-template <class ZT> void read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
+template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {
   istream *is = new ifstream(input_filename);
   *is >> A;
+  int status = 0;
+  if (A.empty())
+  {
+    status = 1;
+    cerr << "File " << input_filename << " was (probably) not opened." << endl;
+  }
   delete is;
+  return status;
 }
 
 /**
@@ -54,11 +61,18 @@ template <class ZT> void read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
    @return
 */
 
-template <class ZT> void read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
+template <class ZT> int read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
 {
   istream *is = new ifstream(input_filename);
   *is >> b;
+  int status = 0;
+  if (b.empty())
+  {
+    status = 1;
+    cerr << "File " << input_filename << " was (probably) not opened." << endl;
+  }
   delete is;
+  return status;
 }
 
 /**
@@ -293,19 +307,23 @@ int test_filename(const char *input_filename, const char *output_filename,
                   const Test test = SVP_ENUM)
 {
   ZZ_mat<ZT> A;
-  read_matrix(A, input_filename);
+  int status = 0;
+  status |= read_matrix(A, input_filename);
 
   IntVect b;
-  read_vector(b, output_filename);
+  status |= read_vector(b, output_filename);
 
   switch (test)
   {
   case SVP_ENUM:
-    return test_svp<ZT>(A, b);
+    status |= test_svp<ZT>(A, b);
+    return status;
   case DSVP_ENUM:
-    return test_dual_svp<ZT>(A, b);
+    status |= test_dual_svp<ZT>(A, b);
+    return status;
   case DSVP_REDUCE:
-    return test_dsvp_reduce<ZT>(A, b);
+    status |= test_dsvp_reduce<ZT>(A, b);
+    return status;
   }
 
   cerr << "Unknown test." << endl;

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -16,6 +16,7 @@
 
 #include <cstring>
 #include <fplll.h>
+#include <test_utils.h>
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."
@@ -30,50 +31,6 @@ enum Test
   DSVP_ENUM,
   DSVP_REDUCE
 };
-
-/**
-   @brief Read matrix from `input_filename`.
-
-   @param A
-   @param input_filename
-   @return zero if A is not empty.
-*/
-
-template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
-{
-  istream *is = new ifstream(input_filename);
-  *is >> A;
-  int status = 0;
-  if (A.empty())
-  {
-    status = 1;
-    cerr << "File " << input_filename << " was (probably) not opened." << endl;
-  }
-  delete is;
-  return status;
-}
-
-/**
-   @brief Read vector from `input_filename` into `b`.
-
-   @param b                vector
-   @param input_filename   filename
-   @return
-*/
-
-template <class ZT> int read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
-{
-  istream *is = new ifstream(input_filename);
-  *is >> b;
-  int status = 0;
-  if (b.empty())
-  {
-    status = 1;
-    cerr << "File " << input_filename << " was (probably) not opened." << endl;
-  }
-  delete is;
-  return status;
-}
 
 /**
    @brief Test if SVP function returns vector with right norm.

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -36,7 +36,7 @@ enum Test
 
    @param A
    @param input_filename
-   @return
+   @return zero if A is not empty.
 */
 
 template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -14,9 +14,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include <../tests/test_utils.h>
 #include <cstring>
 #include <fplll.h>
-#include <test_utils.h>
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,0 +1,53 @@
+#ifndef TEST_UTILS_H
+#define TEST_UTILS_H 
+
+#include <fplll.h>
+using namespace std;
+using namespace fplll;
+
+/**
+   @brief Read matrix from `input_filename`.
+
+   @param A matrix
+   @param input_filename
+   @return zero if the file is correctly read, 1 otherwise.
+*/
+template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
+{
+  int status = 0;
+  ifstream is(input_filename);
+  if (!is)
+  {
+    status = 1;
+    cerr << "Could not open file " << input_filename << "." << endl;
+  }  // throw std::runtime_error("could not open input file");
+  is >> A;
+  return status;
+}
+
+/**
+   @brief Read vector from `input_filename` into `b`.
+
+   @param b                vector
+   @param input_filename   filename
+   @return zero if the file is correctly read, 1 otherwise.
+*/
+
+template <class ZT> int read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
+{
+  int status = 0;
+  ifstream is;
+  is.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+  try {
+    is.open(input_filename);
+    is >> b;
+    is.close();
+  }
+  catch (ifstream::failure e) {
+    status = 1;
+    cerr << "Error by reading " << input_filename << "." << endl;
+  }
+  return status;
+}
+
+#endif /* TEST_UTILS_H */


### PR DESCRIPTION
This pull request is supposed to solve Issue #304. I would prefer not to check if A or b are empty, and check instead if the files are correctly opened, but I hope it will be acceptable. On the contrary to the message that reports the issue, only `test_bkz` fails silently.