### PR TITLE
Remove relative path to test_utils.h.

### DIFF
--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -14,7 +14,7 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include "io/json.hpp"
-#include <../tests/test_utils.h>
+#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
 

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -14,9 +14,9 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include "io/json.hpp"
-#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
+#include <test_utils.h>
 
 using json = nlohmann::json;
 

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -13,7 +13,7 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include <../tests/test_utils.h>
+#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
 

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -13,9 +13,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
+#include <test_utils.h>
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_gso.cpp
+++ b/tests/test_gso.cpp
@@ -19,7 +19,7 @@
 #include <gso_interface.h>
 #include <nr/matrix.h>
 //#include <random>
-#include <../tests/test_utils.h>
+#include <test_utils.h>
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -13,9 +13,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
+#include <test_utils.h>
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -13,7 +13,7 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include <../tests/test_utils.h>
+#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
 

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -13,13 +13,13 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
 #include <gso.h>
 #include <gso_gram.h>
 #include <gso_interface.h>
 #include <lll.h>
+#include <test_utils.h>
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -13,7 +13,7 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include <../tests/test_utils.h>
+#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
 #include <gso.h>

--- a/tests/test_sieve.cpp
+++ b/tests/test_sieve.cpp
@@ -1,7 +1,7 @@
 #include <../fplll/sieve/sieve_main.h> /* standalone bin */
-#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
+#include <test_utils.h>
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_sieve.cpp
+++ b/tests/test_sieve.cpp
@@ -1,5 +1,5 @@
 #include <../fplll/sieve/sieve_main.h> /* standalone bin */
-#include <../tests/test_utils.h>
+#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
 

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -14,9 +14,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
+#include <test_utils.h>
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -14,7 +14,7 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include <../tests/test_utils.h>
+#include <test_utils.h>
 #include <cstring>
 #include <fplll.h>
 


### PR DESCRIPTION
In Issue #309, @malb asked about the use of the indirect include of test_utils.h.
Since test_utils.h was added to ```EXTRA_DIST``` in `tests/Makefile.am` in commit `b4f55a25ca0041b4ed70a2bc2aa4c2b23df1cdfc`, this strange indirect include is no more necessary.