### PR TITLE
dd wrapper

### DIFF
--- a/fplll/nr/nr_FP_dd.inl
+++ b/fplll/nr/nr_FP_dd.inl
@@ -43,9 +43,18 @@ inline void FP_NR<dd_real>::get_mpfr(mpfr_t r, mp_rnd_t rnd) const {
   mpfr_add_d (r, r, data._hi(), rnd);
 }
 
-template<>
+
+template<> 
 inline void FP_NR<dd_real>::set_mpfr(mpfr_t r, mp_rnd_t rnd) {
-  data = mpfr_get_ld (r, rnd);
+  
+  double hi;
+  hi = mpfr_get_d (r, rnd);
+  
+  mpfr_t tf;
+  mpfr_init(tf);
+  mpfr_sub_d(tf,r,hi,rnd);
+
+  data = dd_real(hi,mpfr_get_d (tf, rnd));
 }
 
 template<>

--- a/fplll/nr/nr_FP_misc.inl
+++ b/fplll/nr/nr_FP_misc.inl
@@ -113,10 +113,19 @@ inline void FP_NR<dd_real>::set_z(const Z_NR<double>& a, mp_rnd_t /*rnd*/) {
 }
 #endif
 
-/** set_z (from default mpz_t to dd_real) */
+
+/** set_z (from default mpz_t to dd_real) */ 
 template<> template<>
 inline void FP_NR<dd_real>::set_z(const Z_NR<mpz_t>& a, mp_rnd_t /*rnd*/) {
-  data = mpz_get_d(a.get_data());
+
+  double hi = mpz_get_d(a.get_data());
+
+  mpz_t tz;
+  mpz_init(tz);
+  mpz_set_d(tz,hi);
+  mpz_sub(tz,a.get_data(),tz);
+   
+  data = dd_real(hi,mpz_get_d(tz));
 }
 
 #endif


### PR DESCRIPTION
In nr_FP_misc.inl, set_f, the conversion from mpz_t to dd_real was using mpz_get_d, 
modified through high and low doubles. 

In nr_FP_dd.inl, set_mpfr, the conversion from mpfr to dd_real was using mpfr_get_ld, 
modified through high and low doubles.