### PR TITLE
Dot product

### DIFF
--- a/fplll/gso.cpp
+++ b/fplll/gso.cpp
@@ -71,7 +71,7 @@ template <class ZT, class FT> void MatGSO<ZT, FT>::discover_row()
   {
     for (int j = 0; j <= i; j++)
     {
-      dot_product(g(i, j), b[i], b[j], n_known_cols);
+      b[i].dot_product(g(i, j), b[j], n_known_cols);
     }
   }
   else

--- a/fplll/gso.h
+++ b/fplll/gso.h
@@ -249,7 +249,7 @@ template <class ZT, class FT> inline FT &MatGSO<ZT, FT>::get_gram(FT &f, int i, 
   {
     if (gf(i, j).is_nan())
     {
-      dot_product(gf(i, j), bf[i], bf[j], n_known_cols);
+      bf[i].dot_product(gf(i, j), bf[j], n_known_cols);
     }
     f = gf(i, j);
   }

--- a/fplll/nr/matrix.h
+++ b/fplll/nr/matrix.h
@@ -76,13 +76,7 @@ public:
   /** Computes the dot product between two rows of a Matrix */
   inline void dot_product(T &result, const MatrixRow<T> &v0, int n) const
   {
-    FPLLL_DEBUG_CHECK(n > 0 && n <= this->size() && this->size() == v0.size() &&
-                      (this->is_zero(n) || v0.is_zero(n)));
-    result.mul(this->row[0], v0.row[0]);
-    for (int i = 1; i < n; i++)
-    {
-      result.addmul(this->row[i], v0.row[i]);
-    }
+    fplll::dot_product(result, this->row, v0.row, n);
   }
 
   /** Computes (inline) the dot product between two rows of a Matrix */

--- a/fplll/nr/matrix.h
+++ b/fplll/nr/matrix.h
@@ -73,31 +73,30 @@ public:
     row.addmul_si_2exp(v.row, x, expo, n, tmp);
   }
 
+  /** Computes the dot product between two rows of a Matrix */
+  inline void dot_product(T &result, const MatrixRow<T> &v0, int n) const
+  {
+    FPLLL_DEBUG_CHECK(n > 0 && n <= this->size() && this->size() == v0.size() &&
+                      (this->is_zero(n) || v0.is_zero(n)));
+    result.mul(this->row[0], v0.row[0]);
+    for (int i = 1; i < n; i++)
+    {
+      result.addmul(this->row[i], v0.row[i]);
+    }
+  }
+
+  /** Computes (inline) the dot product between two rows of a Matrix */
+  inline void dot_product(T &result, const MatrixRow<T> &v0) const
+  {
+    this->dot_product(result, v0, this->size());
+  }
+
   friend class Matrix<T>;
 
 private:
   MatrixRow(const NumVect<T> &row) : row(const_cast<NumVect<T> &>(row)) {}
   NumVect<T> &row;
 };
-/** Computes the dot product between two rows of a Matrix */
-template <class T>
-void dot_product(T &result, const MatrixRow<T> &v1, const MatrixRow<T> &v2, int n)
-{
-  FPLLL_DEBUG_CHECK(n > 0 && n <= v1.size() && v1.size() == v2.size() &&
-                    (v1.is_zero(n) || v2.is_zero(n)));
-  result.mul(v1[0], v2[0]);
-  for (int i = 1; i < n; i++)
-  {
-    result.addmul(v1[i], v2[i]);
-  }
-}
-
-/** Computes (inline) the dot product between two rows of a Matrix */
-template <class T>
-inline void dot_product(T &result, const MatrixRow<T> &v1, const MatrixRow<T> &v2)
-{
-  dot_product(result, v1, v2, v1.size());
-}
 
 /** Prints a MatrixRow on stream os. */
 template <class T> ostream &operator<<(ostream &os, const MatrixRow<T> &row)

--- a/fplll/nr/numvect.h
+++ b/fplll/nr/numvect.h
@@ -344,7 +344,8 @@ template <class T> int NumVect<T>::size_nz() const
   return i;
 }
 
-template <class T> void dot_product(T &result, const NumVect<T> &v1, const NumVect<T> &v2, int n)
+template <class T>
+inline void dot_product(T &result, const NumVect<T> &v1, const NumVect<T> &v2, int n)
 {
   FPLLL_DEBUG_CHECK(n > 0 && n <= v1.size() && v1.size() == v2.size() &&
                     (v1.is_zero(n) || v2.is_zero(n)));

--- a/fplll/sieve/sieve_gauss.cpp
+++ b/fplll/sieve/sieve_gauss.cpp
@@ -107,7 +107,7 @@ template <class ZT, class F> GaussSieve<ZT, F>::~GaussSieve()
 template <class ZT, class F> void GaussSieve<ZT, F>::add_mat_list(ZZ_mat<ZT> &B)
 {
   Z_NR<ZT> t, current_norm;
-  dot_product(best_sqr_norm, B[0], B[0]);
+  B[0].dot_product(best_sqr_norm, B[0]);
   ListPoint<ZT> *p;
 
   for (int i = 0; i < nr; ++i)

--- a/fplll/svpcvp.cpp
+++ b/fplll/svpcvp.cpp
@@ -47,11 +47,11 @@ static void get_basis_min(Z_NR<mpz_t> &basis_min, const ZZ_mat<mpz_t> &b, int fi
 {
   Z_NR<mpz_t> sq_norm;
   int n = b.get_cols();
-  dot_product(basis_min, b[first], b[first], n);
+  b[first].dot_product(basis_min, b[first], n);
 
   for (int i = first + 1; i < last; i++)
   {
-    dot_product(sq_norm, b[i], b[i], n);
+    b[i].dot_product(sq_norm, b[i], n);
     if (sq_norm < basis_min)
       basis_min = sq_norm;
   }

--- a/fplll/svpcvp.cpp
+++ b/fplll/svpcvp.cpp
@@ -47,11 +47,11 @@ static void get_basis_min(Z_NR<mpz_t> &basis_min, const ZZ_mat<mpz_t> &b, int fi
 {
   Z_NR<mpz_t> sq_norm;
   int n = b.get_cols();
-  sqr_norm(basis_min, b[first], n);
+  dot_product(basis_min, b[first], b[first], n);
 
   for (int i = first + 1; i < last; i++)
   {
-    sqr_norm(sq_norm, b[i], n);
+    dot_product(sq_norm, b[i], b[i], n);
     if (sq_norm < basis_min)
       basis_min = sq_norm;
   }

--- a/fplll/util.h
+++ b/fplll/util.h
@@ -59,24 +59,6 @@ void vector_matrix_product(NumVect<ZT> &result, const NumVect<ZT> &x, const Matr
       result[j].addmul(x[i], m(i, j));
 }
 
-template <class T>
-void scalar_product(T &result, const MatrixRow<T> &v1, const MatrixRow<T> &v2, int n)
-{
-  FPLLL_DEBUG_CHECK(n <= static_cast<int>(v1.size()) && n <= static_cast<int>(v2.size()));
-  T tmp;
-  result.mul(v1[0], v2[0]);
-  for (int i = 1; i < n; i++)
-  {
-    tmp.mul(v1[i], v2[i]);
-    result.add(result, tmp);
-  }
-}
-
-template <class T> inline void sqr_norm(T &result, const MatrixRow<T> &v, int n)
-{
-  scalar_product(result, v, v, n);
-}
-
 const double DEF_GSO_PREC_EPSILON = 0.03;
 
 /**


### PR DESCRIPTION
I propose to remove the function `scalar_product` from ` fplll/util.h` since it is the same as the one described in `fplll/nr/matrix.h`. I also propose to only use the definition of `dot_product` in `fplll/nr/numvect.h` and use it in `fplll/nr/matrix.h`. My tests seem to show that the running times of LLL are not increased by this last modification.
Question : is a function that computes the square norm of a vector (MatrixRow, NumVect) needed? I choose to not have such a function.