### PR TITLE
extend babai vectors when calling size_reduction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,7 @@ matrix:
     before_install:
       - brew update
       - brew reinstall gmp
+      - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm /usr/local/include/c++ ; fi
       - brew install qd autoconf libtool clang-format
 
 install:

--- a/fplll/lll.h
+++ b/fplll/lll.h
@@ -111,6 +111,10 @@ inline bool LLLReduction<ZT, FT>::size_reduction(int kappa_min, int kappa_end,
 {
   if (kappa_end == -1)
     kappa_end = m.d;
+
+  extend_vect(babai_mu, kappa_end);
+  extend_vect(babai_expo, kappa_end);
+
   for (int k = kappa_min; k < kappa_end; k++)
   {
     if ((k > 0 && !babai(k, k, size_reduction_start)) || !m.update_gso_row(k))


### PR DESCRIPTION
Currently, if size_reduction is called before lll is called, we end up with a SEGFAULT.

See https://github.com/fplll/fpylll/issues/110

The peformance penalty should be negligible since there are a few ifs in size_reduction. Also,
branch prediction will be able to do the right thing here, I think.