### PR TITLE
Can use mpir instead of gmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,24 +54,11 @@ fplll is distributed under the [GNU Lesser General Public License](COPYING) (eit
 
 ### Required ###
 
-- GNU MP 4.2.0 or higher [http://gmplib.org/](http://gmplib.org/)
+- GNU MP 4.2.0 or higher [http://gmplib.org/](http://gmplib.org/) or MPIR 1.0.0 or higher [http://mpir.org](http://mpir.org)
 - MPFR 2.3.0 or higher, COMPLETE INSTALLATION [http://www.mpfr.org/](http://www.mpfr.org/)
 - autotools 2.61 or higher
 - g++ 4.9.3 or higher
 
-If GMP and/or MPFR include and lib files are not in the default directories `/usr/include` and
-`/usr/lib`, you have to set the environment variables `CFLAGS` and `LDFLAGS` for instance through the
-configure command line
-
-    ./configure CPPFLAGS="-I/mpfrinclude -I/gmpinclude" LDFLAGS="-L/mpfrlib -L/gmplib"
-
-or
-
-    ./configure CPPFLAGS="-I/mpfrinclude -I/gmpinclude $CPPFLAGD" LDFLAGS="-L/mpfrlib -L/gmplib $LDFLAGS"
-
-if these variables already exist in your environment. This should be modified soon for using
-standard `--with-gmp` and `--with-mpfr` package specifications. The same philosophy applies to the
-(optional) QD library.
 
 ### Optional ###
 - QD 2.3.15 or higher (a C++/Fortran-90 double-double and quad-double package), compile and install
@@ -92,6 +79,17 @@ Then, to compile and install type
 	./configure
 	make
 	make install			# (as root)
+
+If GMP, MPFR and/or MPIR are not in the `$LD_LIBRARY_PATH`, you have to point to the directories where the libraries are, with
+
+    ./configure --with-gmp=/path/to/gmp
+
+or
+
+    ./configure --with-mpfr=/path/to/mpfr
+
+The same philosophy applies to the (optional) QD library. If you want to use
+mpir instead of gmp, use `--enable-mpir`.
 
 You can remove the program binaries and object files from the source code directory by typing `make
 clean`. To also remove the files that `./configure` created (so you can compile the package for a

--- a/configure.ac
+++ b/configure.ac
@@ -56,18 +56,18 @@ AC_PROG_MAKE_SET
 AX_CXX_COMPILE_STDCXX([11],[noext],[mandatory])
 
 # Checks for libraries.
-AC_ARG_WITH(gmp,
-   AS_HELP_STRING([--with-gmp=@<:@=DIR@:>@], [GMP install directory]), [
+AC_ARG_WITH(mpir,
+   AS_HELP_STRING([--with-mpir=@<:@=DIR@:>@], [GMP install directory]), [
       CPPFLAGS="$CPPFLAGS -I$withval/include"
       LDFLAGS="$LDFLAGS -L$withval/lib"
-      gmp_lib_path="$withval/lib"
+      mpir_lib_path="$withval/lib"
    ])
 
-AC_CHECK_LIB(gmp, __gmpz_init, , [AC_MSG_ERROR(
-[GNU MP not found, see http://gmplib.org])])
+AC_CHECK_LIB(mpir, __gmpz_init, , [AC_MSG_ERROR(
+[MPIR not found, see http://mpir.org])])
 
-AC_CHECK_LIB(gmp, __gmp_get_memory_functions, , [AC_MSG_ERROR(
-[GMP version too old, need >= 4.2.0, see http://gmplib.org])])
+AC_CHECK_LIB(mpir, __gmp_get_memory_functions, , [AC_MSG_ERROR(
+[MPIR version too old, need >= 1.0.0, see http://mpir.org])])
 
 AC_ARG_WITH(mpfr,
    AS_HELP_STRING([--with-mpfr=@<:@=DIR@:>@], [MPFR install directory]), [

--- a/configure.ac
+++ b/configure.ac
@@ -56,18 +56,37 @@ AC_PROG_MAKE_SET
 AX_CXX_COMPILE_STDCXX([11],[noext],[mandatory])
 
 # Checks for libraries.
-AC_ARG_WITH(mpir,
-   AS_HELP_STRING([--with-mpir=@<:@=DIR@:>@], [GMP install directory]), [
-      CPPFLAGS="$CPPFLAGS -I$withval/include"
-      LDFLAGS="$LDFLAGS -L$withval/lib"
-      mpir_lib_path="$withval/lib"
-   ])
+AC_ARG_ENABLE(mpir,
+        AS_HELP_STRING([--enable-mpir],
+         [Enable MPIR instead of GMP]))
 
-AC_CHECK_LIB(mpir, __gmpz_init, , [AC_MSG_ERROR(
-[MPIR not found, see http://mpir.org])])
+AS_IF([test "x$enable_mpir" = "xyes"], [
+	AC_ARG_WITH(mpir,
+	   AS_HELP_STRING([--with-mpir=@<:@=DIR@:>@], [MPIR install directory]), [
+	      CPPFLAGS="$CPPFLAGS -I$withval/include"
+	      LDFLAGS="$LDFLAGS -L$withval/lib"
+	      mpir_lib_path="$withval/lib"
+	   ])
+	AC_CHECK_LIB(mpir, __gmpz_init, , [AC_MSG_ERROR(
+	[MPIR not found, see http://mpir.org])])
+	AC_CHECK_LIB(mpir, __gmp_get_memory_functions, , [AC_MSG_ERROR(
+	[MPIR version too old, need >= 1.0.0, see http://mpir.org])])
+        LIBGMP="-lmpir"
+])
 
-AC_CHECK_LIB(mpir, __gmp_get_memory_functions, , [AC_MSG_ERROR(
-[MPIR version too old, need >= 1.0.0, see http://mpir.org])])
+AS_IF([test "x$enable_mpir" != "xyes"], [
+	AC_ARG_WITH(gmp,
+	   AS_HELP_STRING([--with-gmp=@<:@=DIR@:>@], [GMP install directory]), [
+	      CPPFLAGS="$CPPFLAGS -I$withval/include"
+	      LDFLAGS="$LDFLAGS -L$withval/lib"
+	      mpir_lib_path="$withval/lib"
+	   ])
+	AC_CHECK_LIB(gmp, __gmpz_init, , [AC_MSG_ERROR(
+	[GNU MP not found, see http://mpir.org])])
+	AC_CHECK_LIB(gmp, __gmp_get_memory_functions, , [AC_MSG_ERROR(
+	[GMP version too old, need >= 4.2.0, see http://gmplib.org])])
+        LIBGMP="-lgmp"
+])
 
 AC_ARG_WITH(mpfr,
    AS_HELP_STRING([--with-mpfr=@<:@=DIR@:>@], [MPFR install directory]), [

--- a/fplll.pc.in
+++ b/fplll.pc.in
@@ -6,4 +6,4 @@ includedir=@includedir@
 Name: @PACKAGE_NAME@
 Description: lattice algorithms with floating-point computations
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} @LIBQD_LIBADD@ -lgmp -lmpfr -lfplll
+Libs: -L${libdir} @LIBQD_LIBADD@ -lmpir -lmpfr -lfplll

--- a/fplll.pc.in
+++ b/fplll.pc.in
@@ -6,4 +6,4 @@ includedir=@includedir@
 Name: @PACKAGE_NAME@
 Description: lattice algorithms with floating-point computations
 Version: @PACKAGE_VERSION@
-Libs: -L${libdir} @LIBQD_LIBADD@ -lmpir -lmpfr -lfplll
+Libs: -L${libdir} @LIBQD_LIBADD@ @LIBGMP@ -lmpfr -lfplll

--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -93,7 +93,7 @@ libfplll_la_SOURCES=fplll.cpp fplll.h \
 	sieve/sampler_basic.cpp
 
 EXTRA_libfplll_la_SOURCES= svpcvp.cpp
-libfplll_la_LIBADD=-lgmp -lmpfr $(LIBQD_LIBADD)
+libfplll_la_LIBADD=-lmpir -lmpfr $(LIBQD_LIBADD)
 libfplll_la_LDFLAGS=-no-undefined -version-info @FPLLL_LT_CURRENT@:@FPLLL_LT_REVISION@:@FPLLL_LT_AGE@
 
 libfplllv_la_SOURCES=$(libfplll_la_SOURCES)

--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -93,7 +93,7 @@ libfplll_la_SOURCES=fplll.cpp fplll.h \
 	sieve/sampler_basic.cpp
 
 EXTRA_libfplll_la_SOURCES= svpcvp.cpp
-libfplll_la_LIBADD=-lmpir -lmpfr $(LIBQD_LIBADD)
+libfplll_la_LIBADD=$(LIBGMP) -lmpfr $(LIBQD_LIBADD)
 libfplll_la_LDFLAGS=-no-undefined -version-info @FPLLL_LT_CURRENT@:@FPLLL_LT_REVISION@:@FPLLL_LT_AGE@
 
 libfplllv_la_SOURCES=$(libfplll_la_SOURCES)

--- a/fplll/defs.h
+++ b/fplll/defs.h
@@ -50,8 +50,8 @@
 #endif
 
 #include "fplll_config.h"
-#include <gmp.h>
 #include <mpfr.h>
+#include <mpir.h>
 #ifdef FPLLL_WITH_DPE
 #include "nr/dpe.h"
 #endif

--- a/fplll/defs.h
+++ b/fplll/defs.h
@@ -50,8 +50,13 @@
 #endif
 
 #include "fplll_config.h"
-#include <mpfr.h>
+#ifdef HAVE_LIBMPIR
 #include <mpir.h>
+#endif
+#ifdef HAVE_LIBGMP
+#include <gmp.h>
+#endif
+#include <mpfr.h>
 #ifdef FPLLL_WITH_DPE
 #include "nr/dpe.h"
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,8 +39,8 @@ AM_LDFLAGS = -L$(STAGEDIR) -Wl,-rpath,$(STAGEDIR) -lfplll -no-install $(LIBQD_LI
 
 TESTS = test_nr test_lll test_cvp test_svp test_bkz test_pruner test_sieve test_gso test_lll_gram
 
-test_pruner_LDADD=-lgmp -lmpfr $(LIBQD_LIBADD)
-test_sieve_LDADD=-lgmp -lmpfr $(LIBQD_LIBADD)
+test_pruner_LDADD=-lmpir -lmpfr $(LIBQD_LIBADD)
+test_sieve_LDADD=-lmpir -lmpfr $(LIBQD_LIBADD)
 
 test_nr_SOURCES = test_nr.cpp
 test_lll_SOURCES = test_lll.cpp

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -39,8 +39,8 @@ AM_LDFLAGS = -L$(STAGEDIR) -Wl,-rpath,$(STAGEDIR) -lfplll -no-install $(LIBQD_LI
 
 TESTS = test_nr test_lll test_cvp test_svp test_bkz test_pruner test_sieve test_gso test_lll_gram
 
-test_pruner_LDADD=-lmpir -lmpfr $(LIBQD_LIBADD)
-test_sieve_LDADD=-lmpir -lmpfr $(LIBQD_LIBADD)
+test_pruner_LDADD=$(LIBGMP) -lmpfr $(LIBQD_LIBADD)
+test_sieve_LDADD=$(LIBGMP) -lmpfr $(LIBQD_LIBADD)
 
 test_nr_SOURCES = test_nr.cpp
 test_lll_SOURCES = test_lll.cpp


### PR DESCRIPTION
The goal of this PR is to allow to use mpir instead of gmp. The mechanism is maybe not optimal, since it is needed to use, during the `./configure` step, the option `--enable-mpir`. This is maybe a step to be able to compile `fplll` on Windows, as suggested in the wiki of the fplll days 4.