### PR TITLE
Unused option fplll tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ or
     ./configure --with-mpfr=path/to/mpfr
 
 The same philosophy applies to the (optional) QD library. If you want to use
-mpir instead of gmp, use `--enable-mpir` and `--with-mpir=path/to/mpir".
+mpir instead of gmp, use `--enable-mpir` and `--with-mpir=path/to/mpir`.
 
 You can remove the program binaries and object files from the source code directory by typing `make
 clean`. To also remove the files that `./configure` created (so you can compile the package for a

--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ Then, to compile and install type
 
 If GMP, MPFR and/or MPIR are not in the `$LD_LIBRARY_PATH`, you have to point to the directories where the libraries are, with
 
-    ./configure --with-gmp=/path/to/gmp
+    ./configure --with-gmp=path/to/gmp
 
 or
 
-    ./configure --with-mpfr=/path/to/mpfr
+    ./configure --with-mpfr=path/to/mpfr
 
 The same philosophy applies to the (optional) QD library. If you want to use
-mpir instead of gmp, use `--enable-mpir`.
+mpir instead of gmp, use `--enable-mpir` and `--with-mpir=path/to/mpir".
 
 You can remove the program binaries and object files from the source code directory by typing `make
 clean`. To also remove the files that `./configure` created (so you can compile the package for a
@@ -168,8 +168,8 @@ Options for LLL-reduction:
 * `-p precision` : precision of the floating-point arithmetic, works only with `-f mpfr`.
 * `-f dd` : sets the floating-point type to double-double.
 * `-f qd` : sets the floating-point type to quad-double.
-* `-f dpe` : sets the floating-point type to DPE (default if `m=heuristic/heuristicearly`).
-* `-f double` : sets the floating-point type to double (default if `m=fast/fastearly`).
+* `-f dpe` : sets the floating-point type to DPE (default if `m=heuristic`).
+* `-f double` : sets the floating-point type to double (default if `m=fast`).
 * `-f longdouble` : sets the floating-point type to long double.
 
 * `-z mpz` : sets the integer type to mpz, the integer type of GMP (default).

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ The options are:
 * `-a cvp` : prints the vector in the lattice closest to the input vector.
 * `-v` : verbose mode. 
 * `-nolll` : does not apply to LLL-reduction. In the case of bkz, hkz and svp, by default, the input basis is LLL-reduced before anything else. This option allows to remove that initial LLL-reduction (note that other calls to LLL-reduction may occur during the execution).
-* `-r` `size`, `-c` `size` : ignored, provided for compatibility with previous versions of fplll.
 
 
 Options for LLL-reduction:
@@ -182,9 +181,7 @@ Options for LLL-reduction:
 
 * `-m wrapper` : uses the wrapper. (default if `z=mpz`).
 * `-m fast` : uses the fast method, works only with `-f double`.
-* `-m fastearly` : uses the fast method with early reduction, works only with `-f double`.
 * `-m heuristic` : uses the heuristic method.
-* `-m heuristicearly` : uses the heuristic method with early reduction.
 * `-m proved` : uses the proved version of the algorithm.
 * `-y` : early reduction.
 

--- a/fplll/main.cpp
+++ b/fplll/main.cpp
@@ -381,11 +381,9 @@ void read_options(int argc, char **argv, Options &o)
       o.bkz_dump_gso_filename = argv[ac];
       o.bkz_flags |= BKZ_DUMP_GSO;
     }
-    else if (strcmp(argv[ac], "-c") == 0)
+    else if (strcmp(argv[ac], "-c") == 0 || strcmp(argv[ac], "-r") == 0)
     {
-      ++ac;
-      CHECK(ac < argc, "missing value after -c switch");
-      // o.c=atoi(argv[ac]); // ignored (was the number of columns)
+      ABORT_MSG("option " << argv[ac] << " no more supported");
     }
     else if (strcmp(argv[ac], "-bkzghbound") == 0)
     {
@@ -449,15 +447,11 @@ void read_options(int argc, char **argv, Options &o)
         o.method = LM_HEURISTIC;
       else if (strcmp("fast", argv[ac]) == 0)
         o.method = LM_FAST;
-      else if (strcmp("fastearly", argv[ac]) == 0)
+      else if (strcmp("fastearly", argv[ac]) == 0 || strcmp("heuristicearly", argv[ac]) == 0)
       {
-        o.method    = LM_FAST;
-        o.early_red = true;
-      }
-      else if (strcmp("heuristicearly", argv[ac]) == 0)
-      {
-        o.method    = LM_HEURISTIC;
-        o.early_red = true;
+        string m = string(argv[ac]);
+        // m.substr(0, m.size() - 4) remove early from the string
+        ABORT_MSG("use '-m " << m.substr(0, m.size() - 5) << " -y' instead of " << argv[ac]);
       }
       else
         ABORT_MSG("parse error in -m switch : proved, heuristic, fast, "
@@ -478,12 +472,6 @@ void read_options(int argc, char **argv, Options &o)
       ++ac;
       CHECK(ac < argc, "missing value after -p switch");
       o.precision = atoi(argv[ac]);
-    }
-    else if (strcmp(argv[ac], "-r") == 0)
-    {
-      ++ac;
-      CHECK(ac < argc, "missing value after -r switch");
-      // o.r = atoi(argv[ac]); // ignored (was the number of rows)
     }
     else if (strcmp(argv[ac], "-v") == 0)
     {
@@ -523,10 +511,6 @@ void read_options(int argc, char **argv, Options &o)
            << "       Enable verbose mode\n"
            << "  -nolll\n"
            << "       Does not apply intial LLL-reduction (for bkz, hkz and svp)\n"
-           << "  -c <size>\n"
-           << "       Was the number of columns (ignored)\n"
-           << "  -r <size>\n"
-           << "       Was the number of rows (ignored)\n"
 
            << "  -d <delta> (default=0.99; alias to -delta <delta>)\n"
            << "  -e <eta> (default=0.51; alias to -eta <eta>)\n"
@@ -538,7 +522,7 @@ void read_options(int argc, char **argv, Options &o)
            << "       Floating-point precision (only with -f mpfr)\n"
            << "  -z [mpz|int|long|double]\n"
            << "       Integer type in LLL (default: mpz; long is an alias to int)\n"
-           << "  -m [wrapper|fast|fastearly|heuristic|heuristicearly|proved]\n"
+           << "  -m [wrapper|fast|heuristic|proved]\n"
            << "       LLL version (default: wrapper)\n"
            << "  -y\n"
            << "       Enable early reduction\n"

--- a/fplll/main.cpp
+++ b/fplll/main.cpp
@@ -560,7 +560,7 @@ void read_options(int argc, char **argv, Options &o)
            << "  -bkzdumpgso <file_name>\n"
            << "        Dumps the log of the Gram-Schmidt vectors in specified file\n"
 
-           << "  -of [bcstuv]\n"
+           << "  -of [b|c|s|t|u|v]\n"
            << "        Output formats.\n"
 
            << "Please refer to https://github.com/fplll/fplll/README.md for more informations.\n";


### PR DESCRIPTION
This PR removes the ability to use options:
* `-c` and `-r`, since these options were ignored
* `-m [fastearly|heuristicearly]` and prefer the use of `-m [fast|heuristic] -y`
