### PR TITLE
Deprecated function in mpfr 4.0.0.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -101,8 +101,6 @@ AC_CHECK_LIB(mpfr, mpfr_add, , [AC_MSG_ERROR(
 AC_CHECK_LIB(mpfr, mpfr_fms, , [AC_MSG_ERROR(
 [MPFR version too old, need >= 2.3.0, see http://www.mpfr.org])])
 
-AC_CHECK_LIB(mpfr, mpfr_rootn_ui, AC_DEFINE([MPFR_4], [1], [MPFR version is >= 4.0.0]), )
-
 AC_ARG_WITH(qd, AS_HELP_STRING([--with-qd=@<:@=DIR@:>@], [quaddouble install directory]),)
 
 AS_IF([test "x$with_qd" != "xno"], [

--- a/configure.ac
+++ b/configure.ac
@@ -101,6 +101,8 @@ AC_CHECK_LIB(mpfr, mpfr_add, , [AC_MSG_ERROR(
 AC_CHECK_LIB(mpfr, mpfr_fms, , [AC_MSG_ERROR(
 [MPFR version too old, need >= 2.3.0, see http://www.mpfr.org])])
 
+AC_CHECK_LIB(mpfr, mpfr_rootn_ui, AC_DEFINE([MPFR_4], [1], [MPFR version is >= 4.0.0]), )
+
 AC_ARG_WITH(qd, AS_HELP_STRING([--with-qd=@<:@=DIR@:>@], [quaddouble install directory]),)
 
 AS_IF([test "x$with_qd" != "xno"], [

--- a/fplll/fplll_config.h.in
+++ b/fplll/fplll_config.h.in
@@ -32,7 +32,4 @@
 #undef HAVE_LIBGMP
 #undef HAVE_LIBMPIR
 
-/* Use mpfr_rootn_ui instead of mpfr_root if MPFR version is >= 4.0.0 */
-#undef MPFR_4
-
 #endif //FPLLL_CONFIG__H

--- a/fplll/fplll_config.h.in
+++ b/fplll/fplll_config.h.in
@@ -28,4 +28,11 @@
 /* Recursive enumeration enabled */
 #undef FPLLL_WITH_RECURSIVE_ENUM
 
+/* Switch between GMP and MPIR */
+#undef HAVE_LIBGMP
+#undef HAVE_LIBMPIR
+
+/* Use mpfr_rootn_ui instead of mpfr_root if MPFR version is >= 4.0.0 */
+#undef MPFR_4
+
 #endif //FPLLL_CONFIG__H

--- a/fplll/nr/nr_FP_mpfr.inl
+++ b/fplll/nr/nr_FP_mpfr.inl
@@ -5,8 +5,6 @@
 #ifndef FPLLL_NR_FP_MPFR_H
 #define FPLLL_NR_FP_MPFR_H
 
-#include "../fplll_config.h"
-
 FPLLL_BEGIN_NAMESPACE
 
 /* MPFR specialization */
@@ -251,11 +249,11 @@ inline void FP_NR<mpfr_t>::sqrt(const FP_NR<mpfr_t>& a, mp_rnd_t rnd) {
 
 template<>
 inline void FP_NR<mpfr_t>::root(const FP_NR<mpfr_t>& a, unsigned int k, mp_rnd_t rnd) {
-#ifdef MPFR_4
+#if MPFR_VERSION_MAJOR >= 4
   mpfr_rootn_ui(data, a.data, k, rnd);
-#else // MPFR_4
+#else // MPFR_VERSION_MAJOR >= 4
   mpfr_root(data, a.data, k, rnd);
-#endif // MPFR_4
+#endif // MPFR_VERSION_MAJOR >= 4
 }
 
 template<>

--- a/fplll/nr/nr_FP_mpfr.inl
+++ b/fplll/nr/nr_FP_mpfr.inl
@@ -5,6 +5,8 @@
 #ifndef FPLLL_NR_FP_MPFR_H
 #define FPLLL_NR_FP_MPFR_H
 
+#include "../fplll_config.h"
+
 FPLLL_BEGIN_NAMESPACE
 
 /* MPFR specialization */
@@ -249,7 +251,11 @@ inline void FP_NR<mpfr_t>::sqrt(const FP_NR<mpfr_t>& a, mp_rnd_t rnd) {
 
 template<>
 inline void FP_NR<mpfr_t>::root(const FP_NR<mpfr_t>& a, unsigned int k, mp_rnd_t rnd) {
+#ifdef MPFR_4
+  mpfr_rootn_ui(data, a.data, k, rnd);
+#else // MPFR_4
   mpfr_root(data, a.data, k, rnd);
+#endif // MPFR_4
 }
 
 template<>


### PR DESCRIPTION
Since version 4.0.0 of mpfr,
> `mpfr_root` [is] deprecated and will be removed in a future release

These changes must allow to use `mpfr_rootn_ui` instead of `mpfr_root` if mpfr 4.0.0 is installed without breaking the ability to use older versions of mpfr.