### PR TITLE
Fix Solaris issues

### DIFF
--- a/fplll/nr/dpe.h
+++ b/fplll/nr/dpe.h
@@ -708,14 +708,14 @@ DPE_INLINE void dpe_ugly_log(dpe_t x, const dpe_t y)
 DPE_INLINE void dpe_ugly_exp(dpe_t x, const dpe_t y)
 {
   // printf ("## exp is %ld\n", DPE_EXP(y));
-  dpe_set_d(x, exp(((double)DPE_MANT(y)) * pow(2, ((double)DPE_EXP(y)))));
+  dpe_set_d(x, exp(((double)DPE_MANT(y)) * pow(2.0, ((double)DPE_EXP(y)))));
 }
 
 /* More hacks */
 /* x = y^k */
 DPE_INLINE void dpe_pow_si(dpe_t x, const dpe_t y, const unsigned int k)
 {
-  DPE_MANT(x) = pow(DPE_MANT(y), k);
+  DPE_MANT(x) = pow(DPE_MANT(y), (double)k);
   DPE_EXP(x)  = DPE_EXP(y) * k;
   dpe_normalize(x);
 }

--- a/fplll/sieve/sieve_gauss_2sieve.cpp
+++ b/fplll/sieve/sieve_gauss_2sieve.cpp
@@ -33,7 +33,7 @@ template <class ZT, class F> Z_NR<ZT> GaussSieve<ZT, F>::update_p_2reduce(ListPo
     for (lp_it = List.begin(); lp_it != List.end(); ++lp_it)
     {
       v = *lp_it;
-      if (p->norm < v->norm)
+      if ((p->norm) < v->norm)
         break;
 
       /* if there is one reduction the vector should re-pass the list */

--- a/fplll/sieve/sieve_gauss_3sieve.cpp
+++ b/fplll/sieve/sieve_gauss_3sieve.cpp
@@ -27,7 +27,7 @@ GaussSieve<ZT, F>::update_p_3reduce_2reduce(ListPoint<ZT> *p,
     for (lp_it = List.begin(); lp_it != List.end(); ++lp_it)
     {
       v = *lp_it;
-      if (p->norm < v->norm)
+      if ((p->norm) < v->norm)
         break;
       if (half_2reduce(p, v))
       {
@@ -166,7 +166,7 @@ template <class ZT, class F> Z_NR<ZT> GaussSieve<ZT, F>::update_p_3reduce(ListPo
         continue;
       }
       ++lp_it2;
-      if (v1->norm < p->norm)
+      if ((v1->norm) < p->norm)
       {
         vnew2 = new_listpoint<ZT>(nc);
         if (check_3reduce(v1, p, v2, vnew2) != 1)

--- a/fplll/sieve/sieve_gauss_4sieve.cpp
+++ b/fplll/sieve/sieve_gauss_4sieve.cpp
@@ -15,7 +15,7 @@ void GaussSieve<ZT, F>::update_p_4reduce_aux(ListPoint<ZT> *p,
   for (lp_it = List.begin(); lp_it != List.end(); ++lp_it)
   {
     v = *lp_it;
-    if (p->norm < v->norm)
+    if ((p->norm) < v->norm)
       break;
   }
   lp_it_k = lp_it;
@@ -119,7 +119,7 @@ template <class ZT, class F> Z_NR<ZT> GaussSieve<ZT, F>::update_p_4reduce_3reduc
         continue;
       }
       ++lp_it2;
-      if (v1->norm < p->norm)
+      if ((v1->norm) < p->norm)
       {
         /*cout << "#   --- here 1 " << endl;
         cout << v1->norm << endl;
@@ -274,7 +274,7 @@ template <class ZT, class F> Z_NR<ZT> GaussSieve<ZT, F>::update_p_4reduce(ListPo
         }
         ++lp_it3;
         /* (v1, p, v2, v3) or (v1, v2, p, v3) */
-        if (v1->norm < p->norm)
+        if ((v1->norm) < p->norm)
         {
           /* (v1, p, v2, v3) */
           if (v2->norm > p->norm)


### PR DESCRIPTION
This fixes two issues when compiling on Solaris with GCC-5.4.0.

The first is an issue with `pow()`:
```
nr/dpe.h: In function 'void dpe_pow_si(dpe_struct*, const dpe_struct*, unsigned int)':
nr/dpe.h:718:35: error: call of overloaded 'pow(const double&, const unsigned int&)' is ambiguous
   DPE_MANT(x) = pow(DPE_MANT(y), k);
```

The second is GCC bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=10200
The existence of a templated `norm` function causes GCC to misparse `if (p->norm < v->norm)`