### PR TITLE
Added givens

### DIFF
--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -30,7 +30,7 @@ nobase_include_fplll_HEADERS=defs.h fplll.h \
 	nr/nr_Z_mpz.inl \
 	nr/numvect.h \
 	util.h \
-	svpcvp.h bkz.h lll.h gso_interface.h gso_gram.h gso.h  \
+	svpcvp.h bkz.h lll.h gso_interface.h gso_gram.h gso.h gso_givens.h \
 	enum/evaluator.h \
 	wrapper.h \
 	bkz_param.h \
@@ -80,7 +80,7 @@ libfplll_la_SOURCES=fplll.cpp fplll.h \
 	wrapper.cpp wrapper.h \
 	bkz.cpp bkz.h \
 	bkz_param.cpp bkz_param.h \
-	gso_interface.cpp gso_interface.h gso_gram.cpp gso_gram.h gso.cpp gso.h \
+	gso_interface.cpp gso_interface.h gso_gram.cpp gso_gram.h gso.cpp gso.h gso_givens.cpp gso_givens.h \
 	pruner.cpp pruner.h \
 	sieve/sieve_gauss.cpp \
 	sieve/sieve_gauss.h  \

--- a/fplll/gso_givens.cpp
+++ b/fplll/gso_givens.cpp
@@ -1,0 +1,860 @@
+/* Copyright (C) 2005-2008 Damien Stehle.
+   Copyright (C) 2007 David Cade.
+   Copyright (C) 2011 Xavier Pujol.
+
+   This file is part of fplll. fplll is free software: you
+   can redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License as published by the Free Software Foundation,
+   either version 2.1 of the License, or (at your option) any later version.
+
+   fplll is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with fplll. If not, see <http://www.gnu.org/licenses/>. */
+
+/* Template source file */
+
+#include "gso_givens.h"
+
+FPLLL_BEGIN_NAMESPACE
+
+
+template<class ZT, class FT> void MatGSOGivens<ZT,FT>::add_operation(FT c, FT s, int row, int col) {
+  ops_c(row,col) = c;
+  ops_s(row,col) = s;  
+}
+
+// The givens rotation introduces a zero in place  (k,j) in the matrix, and puts the residue
+// on place (k,i). Most of the cases, j = i-1
+//              j|i
+//   _________________________
+//  |                         |
+//  |_________________________|
+//k |__________|x|y|__________|
+//  |                         |
+//  |                         |
+//  |_________________________|
+//
+//        TRAMSFORMS TO
+//              
+//
+//              j|i
+//   _________________________
+//  |           * *           |
+//  |_________________________|
+//k |__________|x|0|__________|
+//  |           * *           |
+//  |           * *           |
+//  |_________________________|
+//
+//       
+//
+//  The stars indicate that the values
+//  there can be changed [in linear combinations]. 
+// The rest of  the matrix is fixed.
+// 
+
+template <class ZT, class FT> void MatGSOGivens<ZT,FT>::givens_rotation(int row, int col){
+  if (l_givens(row,col).is_zero()) {
+    add_operation(1.0,0.0,row,col);
+    return;
+  }
+
+  FT c, s, tempvar;
+
+  // computes c,s
+  tempvar.hypot(l_givens(row, col-1), l_givens(row, col));
+  c.div(l_givens(row, col-1), tempvar);
+  s.div(l_givens(row, col), tempvar);
+
+  // applies the c,s-rotation to place (row,col)
+  virtual_givens_rotation(row,col,c,s);
+
+  // adds the operation to the operation-matrices.
+  add_operation(c,s,row,col);  
+
+  // force zero on the place where a zero should be.
+  l_givens(row,col) = 0.0;
+
+
+}
+
+
+// Applies a 'virtual' givens rotation, meaning
+// that the c and s are not from the row to which
+// you apply the rotation.
+template <class ZT, class FT> void MatGSOGivens<ZT,FT>::virtual_givens_rotation(int row, int col, FT c, FT s){
+    FT tempvar,tempvar2;
+    tempvar = l_givens(row, col-1); 
+    tempvar2 = l_givens(row, col); 
+    l_givens(row, col-1).mul(tempvar, c); 
+    l_givens(row, col-1).addmul(tempvar2, s);
+
+    l_givens(row, col).neg(s);
+    l_givens(row, col).mul(tempvar, l_givens(row, col));
+    l_givens(row, col).addmul(tempvar2, c);
+
+}
+
+
+
+
+
+// The givens_row_reduction introduces a zero-sequence from the diagonal of row_k
+// to the 'rightmost_nonzero_entry' column.
+// 
+//              k|        r
+//   _________________________
+//  |                         |    
+//  |_________________________|
+//k |__________|a|b|c|d|e|f|__|
+//  |                         |
+//  |                         |
+//  |_________________________|
+//
+//        TRAMSFORMS TO
+//              
+//
+//              k|        r
+//   _________________________
+//  |           * * * * * *   |    
+//  |_________________________|
+//k |__________|z|0|0|0|0|0|__|
+//  |           * * * * * *   |
+//  |           * * * * * *   |
+//  |-------------------------|
+//
+// The stars indicate that the entries
+// there might be changed into linear
+// combinations of their neighbour-entries.
+// The rest of the matrix is fixed.
+
+
+template <class ZT, class FT> void MatGSOGivens<ZT,FT>::givens_row(int row, int rightmost_nonzero_entry){
+  for (int i = rightmost_nonzero_entry; i > row; i--)
+    givens_rotation(row,i);
+}
+
+template <class ZT, class FT> void MatGSOGivens<ZT,FT>::givens_row(int row){
+  givens_row(row,l_givens.get_cols()-1); 
+}
+
+
+
+
+// Applies to row 'row' all givens operation
+// from the previous rows. This is because
+// we postpone the column operations up to the
+// moment that we really need them.
+
+template <class ZT, class FT> void MatGSOGivens<ZT,FT>::apply_givens_operations(int row){
+
+	  for(int i = 0; i < row; i++) {
+	  for(int j = l_givens.get_cols()-1; j>i; j--) {
+	    // maybe do a check if ops_s(i,j) is zero?
+	    virtual_givens_rotation(row,j, ops_c(i,j), ops_s(i,j));
+	  }
+	  }
+
+
+}
+
+
+/*
+template <class ZT, class FT> void MatGSOGivens<ZT,FT>::apply_givens_operations(int start_row, int end_row){
+        FT tempvar,tempvar2;
+    for(int i = 0; i < start_row; i++) {
+    for(int j = l_givens.get_cols()-1; j>i; j--) {
+      // maybe do a check if ops_s(i,j) is zero?
+
+      for(int k = start_row; k < end_row; k++) {
+        tempvar = l_givens(k, j-1); 
+        tempvar2 = l_givens(k, j); 
+        l_givens(k, j-1).mul(tempvar, ops_c(i,j)); 
+        l_givens(k, j-1).addmul(tempvar2, ops_s(i,j));
+
+        l_givens(k, j).neg(ops_s(i,j));
+        l_givens(k, j).mul(tempvar, l_givens(k, j));
+        l_givens(k, j).addmul(tempvar2, ops_c(i,j));
+      }
+    }
+    }
+
+
+}
+*/
+/*
+template <class ZT, class FT> void MatGSOGivens<ZT,FT>::triangularize(int start_row, int end_row){
+        FT tempvar,tempvar2,c,s;
+
+    for(int i = start_row; i < end_row; i++) {
+        for(int j = l_givens.get_cols()-1; j>i; j--) {
+          // maybe do a check if ops_s(i,j) is zero?
+          if (l_givens(i,j).is_zero()) {
+            add_operation(1.0,0.0,i,j);
+            continue;
+          }          
+          tempvar.hypot(l_givens(i, j-1), l_givens(i, j));
+          ops_c(i,j).div(l_givens(i, j-1), tempvar);
+          ops_s(i,j).div(l_givens(i, j), tempvar);
+          c = ops_c(i,j);
+          s = ops_s(i,j);
+
+          for(int k = i; k < end_row; k++) {
+            tempvar = l_givens(k, j-1); 
+            tempvar2 = l_givens(k, j); 
+            l_givens(k, j-1).mul(tempvar, c); 
+            l_givens(k, j-1).addmul(tempvar2, s);
+
+            l_givens(k, j).neg(s);
+            l_givens(k, j).mul(tempvar, l_givens(k, j));
+            l_givens(k, j).addmul(tempvar2, c);
+          }
+          l_givens(i,j) = 0.0; // force 0.
+        }
+    compute_mu_and_r(i);
+    }
+
+}
+*/
+
+template <class ZT, class FT> bool MatGSOGivens<ZT, FT>::real_update_gso_row(int row)
+{
+          // copies b[row] to l_givens[row]
+         copy_b_to_l_givens(row);
+
+         // applies all previous givens operations to l_givens[row]
+         apply_givens_operations(row);
+
+         // givens-reduces l_givens[row], and stores (c,s) values in the ops-matrices
+         givens_row(row);
+
+         // computes mu and r. 
+         // TODO to make lazy!!!
+         compute_mu_and_r(row);
+
+         // Discover the new row.
+        if (row >= n_known_rows)
+        {
+          discover_row();
+        }
+        return true;
+}
+
+template <class ZT, class FT> bool MatGSOGivens<ZT, FT>::update_gso_row(int row, int last_j)
+{
+
+  if (full_lazy) {
+    if (n_known_rows < d) {  // Only the first time the full GSO is computed
+      for(int i = n_known_rows; i < d; i++)
+        real_update_gso_row(i); 
+    }    
+    return true; // Rest of the time, do NO recomputation.
+  }
+
+  if (move_lazy) {
+    // If you did 'move´ lazy, the Givens-operations of earlier rows need to be recomputed...!
+    for(int i = lazy_row_start; i < row; i++)
+        real_update_gso_row(i);  
+    lazy_row_start = d;  
+  }
+
+  return real_update_gso_row(row);
+}
+
+
+
+
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::recompute_givens_matrix(int start_row, int last_row)
+{
+  for(int i = start_row; i < last_row; i++) {
+    real_update_gso_row(i);
+  }
+
+}
+
+
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::recompute_givens_matrix(int last_row)
+{
+  recompute_givens_matrix(0,last_row);
+}
+
+
+// Includes also row-exponent compatibility.
+// Essentially copies b[row] to l_givens[row].
+
+template <class ZT, class FT> void MatGSOGivens<ZT,FT>::copy_b_to_l_givens(int row){
+      if (enable_row_expo){
+          int n = b.get_cols();
+          long max_expo = LONG_MIN;
+          for (int j = 0; j < n; j++)
+          {
+            b(row, j).get_f_exp(l_givens(row, j), tmp_col_expo[j]);
+            max_expo = max(max_expo, tmp_col_expo[j]);
+          }
+          for (int j = 0; j < n; j++)
+          {
+            l_givens(row, j).mul_2si(l_givens(row, j), tmp_col_expo[j] - max_expo);
+          }
+          row_expo[row] = max_expo;
+          
+          //normalize_givens_row(row);
+      } else {
+        for (int j = 0; j < l_givens.get_cols(); j++)
+        {
+          l_givens(row, j).set_z(b(row, j));
+        }  
+      }
+}
+
+
+
+
+
+
+
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::compute_mu_and_r_columns(int starting_column, int last_column)
+{
+  for(int col = starting_column; col <= last_column; col++) {
+  	r(col,col).mul(l_givens(col,col),l_givens(col,col));
+    for (int i = col; i < n_known_rows; i++)
+      mu(i,col).div(l_givens(i,col),l_givens(col,col));
+
+    ftmp1 = l_givens(col,col);
+    for (int i = col; i < n_known_rows; i++)
+      r(i, col).mul(ftmp1, l_givens(i, col));  
+
+  }
+}
+
+
+
+// TODO MAKE LAZY
+
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::compute_mu_and_r(int row)
+{
+      for(int k = 0; k < row; k++) {
+        mu[row][k].div(l_givens[row][k],l_givens(k,k));
+        r[row][k].mul(l_givens[row][k],l_givens(k,k));
+      }
+      r[row][row].mul(l_givens[row][row],l_givens[row][row]);
+
+}
+
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::update_bf(int i)
+{
+
+  if (enable_row_expo)
+  {
+    int n = b.get_cols(); 
+
+    //long max_expo = LONG_MIN;
+    for (int j = 0; j < n; j++)
+    {
+      b(i, j).get_f_exp(bf(i, j), tmp_col_expo[j]);
+      //max_expo = max(max_expo, tmp_col_expo[j]);
+    }
+    for (int j = 0; j < b.get_cols(); j++)
+    	bf(i,j).mul_2si(bf(i,j),tmp_col_expo[j]-row_expo[i]);
+    //{
+    //  bf(i, j).mul_2si(bf(i, j), - );
+    //}
+    //row_expo[i] = max_expo;
+  } else {
+    for (int j = 0; j < b.get_cols(); j++)
+    {
+      bf(i, j).set_z(b(i, j));
+    }
+  }
+
+}
+
+// "Full columns" ... does it improve time?
+
+
+template <class ZT, class FT> void MatGSOGivens<ZT,FT>::full_column_givens_rotation(int row, int col){
+
+  FT c, s, tempvar;
+  tempvar.hypot(l_givens(row, col-1), l_givens(row, col));
+  c.div(l_givens(row, col-1), tempvar);
+  s.div(l_givens(row, col), tempvar);
+
+  for (int k = row; k < n_known_rows; k++)  
+  {
+    ftmp1 = l_givens(k, col-1); 
+    ftmp2 = l_givens(k, col); 
+    l_givens(k, col-1).mul(ftmp1, c); // r_(k,col_i) = c*r_(k,col_i) + s*r_(k,col_j)
+    l_givens(k, col-1).addmul(ftmp2, s);
+
+    l_givens(k, col).neg(s);
+    l_givens(k, col).mul(ftmp1, l_givens(k, col));
+    l_givens(k, col).addmul(ftmp2, c); // r_(k,col_j) = -s*r_(k,col_i) + c*r_(k,col_j)
+  }
+  // "Forcing" zero 
+  //l_givens(row, col) = 0.0;
+
+}
+
+template <class ZT, class FT> void MatGSOGivens<ZT,FT>::full_column_givens_row(int row, int rightmost_nonzero_entry){
+  for (int i = rightmost_nonzero_entry; i > row; i--)
+    full_column_givens_rotation(row, i);
+}
+
+
+
+
+
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::invalidate_gram_row(int i)
+{
+	// TODO maybe some functionality later.
+}
+
+
+
+
+// Givens ready.
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::row_add(int i, int j)
+{
+ 
+	  b[i].add(b[j], b.get_cols());
+	  if (enable_transform)  {
+	    u[i].add(u[j]);
+	    if (enable_inverse_transform)
+	      u_inv_t[j].sub(u_inv_t[i]);
+	  }
+
+
+    if (j < i) {
+      if (enable_row_expo) {
+
+        l_givens[i].addmul_2exp(l_givens[j], 1.0, row_expo[j] - row_expo[i], ftmp1);
+
+        // TODO LAZY
+        compute_mu_and_r(i);
+      } else {
+        // Doing b_i <- b_i + c b_j doesn't affect the triangularity
+
+        l_givens[i].add(l_givens[j],j+1);
+
+        // TODO: making this lazy
+        compute_mu_and_r(i);
+
+      }
+
+
+     } else {
+      throw std::runtime_error("Error: i < j in row_add");
+
+    }
+  
+}
+
+// Givens ready
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::row_sub(int i, int j)
+{
+
+  b[i].sub(b[j], b.get_cols());
+  if (enable_transform)
+  {
+    u[i].sub(u[j]);
+    if (enable_inverse_transform)
+      u_inv_t[j].add(u_inv_t[i]);
+  }
+
+    if (j < i) {
+      if (enable_row_expo) {
+        l_givens[i].addmul_2exp(l_givens[j], -1.0, row_expo[j] - row_expo[i], ftmp1);
+        compute_mu_and_r(i);
+      } else {
+        // Doing b_i <- b_i + c b_j doesn't affect the triangularity
+        l_givens[i].sub(l_givens[j],j+1);
+    
+
+      // TODO: making this lazy
+
+      compute_mu_and_r(i);      
+      }
+
+    } else {
+      // i < j, so affects triangularity 
+      throw std::runtime_error("Error: i < j in row_sub");
+
+    }
+}
+
+// Givens-ready
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::row_addmul_si(int i, int j, long x)
+{
+
+  // TODO addmul_si not possible, because
+  // l_givens is of type NumVect
+  // and not of MatrixRow
+  // Is this well-resolved??
+
+  b[i].addmul_si(b[j], x, b.get_cols());
+
+  if (enable_transform)
+  {
+    u[i].addmul_si(u[j], x);
+    if (enable_inverse_transform)
+      u_inv_t[j].addmul_si(u_inv_t[i], -x);
+  }
+
+
+    if (j < i) {
+      if (enable_row_expo) {
+        l_givens[i].addmul_2exp(l_givens[j], x, row_expo[j] - row_expo[i], ftmp1);
+        compute_mu_and_r(i);
+      } else {
+
+      // Doing b_i <- b_i + c b_j doesn't affect the 
+
+      // TODO Changing to addmul okay?
+      l_givens[i].addmul(l_givens[j],x,j+1); // j+1 really needed!
+  
+      // TODO: making this lazy
+      compute_mu_and_r(i);    
+
+      }
+
+
+      
+     } else {
+        throw std::runtime_error("Error: i < j in row_addmul_si");
+      }
+
+}
+
+
+// TODO Still needs to be implemented!
+template <class ZT, class FT>
+void MatGSOGivens<ZT, FT>::row_addmul_si_2exp(int i, int j, long x, long expo)
+{
+  throw std::runtime_error("Error in row_addmul_si_2exp: exponents are not yet implemented for givens rotations");
+  b[i].addmul_si_2exp(b[j], x, expo, b.get_cols(), ztmp1);
+  if (enable_transform)
+  {
+    u[i].addmul_si_2exp(u[j], x, expo, ztmp1);
+    if (enable_inverse_transform)
+      u_inv_t[j].addmul_si_2exp(u_inv_t[i], -x, expo, ztmp1);
+  }
+
+
+    if (j < i) {
+      if (enable_row_expo) {
+        long double dx = (long double) x;
+
+        l_givens[i].addmul_2exp(l_givens[j], dx, row_expo[j] - row_expo[i] + expo, ftmp1);
+        compute_mu_and_r(i);
+      } else {      
+      // Doing b_i <- b_i + c b_j doesn't affect the triangularity
+
+      l_givens[i].addmul_2exp(l_givens[j],x,expo, ftmp1);
+
+
+
+      // TODO: making this lazy
+      compute_mu_and_r(i);      
+      }
+    
+     
+     } else {
+      throw std::runtime_error("Error: i < j in row_addmul_si");
+    }
+
+
+}
+
+
+template <class ZT, class FT>
+void MatGSOGivens<ZT, FT>::row_addmul_2exp(int i, int j, const ZT &x, long expo)
+{
+  b[i].addmul_2exp(b[j], x, expo, b.get_cols(), ztmp1);
+  if (enable_transform)
+  {
+    u[i].addmul_2exp(u[j], x, expo, ztmp1);
+    if (enable_inverse_transform)
+    {
+      ZT minus_x;
+      minus_x.neg(x);
+      u_inv_t[j].addmul_2exp(u_inv_t[i], minus_x, expo, ztmp1);
+    }
+  }
+
+
+  FT tmpx;
+  tmpx.set_z(x);
+
+    if (j < i) {
+      // Doing b_i <- b_i + c b_j doesn't affect the triangularity
+
+      if (enable_row_expo) {
+        long double dx = x.get_d();
+        
+        l_givens[i].addmul_2exp(l_givens[j], dx, row_expo[j] - row_expo[i] + expo, ftmp1);
+        // LAZY
+        compute_mu_and_r(i);        
+      } else {   
+
+
+      for (int k = 0; k < j; k++) {
+          ftmp1.mul(l_givens(j, k), tmpx);
+          ftmp1.mul_2si(ftmp1, expo);
+          l_givens(i,k).add(l_givens(i,k),ftmp1);
+      }
+      // LAZY
+      compute_mu_and_r(i);      
+      }
+
+    
+     } else {
+    throw std::runtime_error("Error: i < j in row_addmul_2exp");
+    }
+
+
+
+}
+
+// in row_addmul_we we must have i > j
+template <class ZT, class FT>
+void MatGSOGivens<ZT, FT>::row_addmul_we(int i, int j, const FT &x, long expo_add)
+{
+
+  FPLLL_DEBUG_CHECK(j >= 0 && /* i > j &&*/ i < n_known_rows && j < n_source_rows);
+  long expo;
+  long lx = x.get_si_exp_we(expo, expo_add);
+
+  if (expo == 0)
+  {
+    if (lx == 1)
+      row_add(i, j);
+    else if (lx == -1)
+      row_sub(i, j);
+    else if (lx != 0)
+      row_addmul_si(i, j, lx);
+  }
+  else if (row_op_force_long)
+  {
+    row_addmul_si_2exp(i, j, lx, expo);
+  }
+  else
+  {
+    x.get_z_exp_we(ztmp2, expo, expo_add);
+    row_addmul_2exp(i, j, ztmp2, expo);
+  }
+}
+
+
+
+// In row_swap, i < j
+// Is Givens-ready.
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::row_swap(int i, int j)
+{
+  FPLLL_DEBUG_CHECK(!enable_inverse_transform);
+   if (j < i)  
+   {
+   	int k = i;
+   	i = j;
+   	j = k;
+   }
+
+  // *******************
+  // Swap the rows of b
+  // ********************
+  b.swap_rows(i, j);
+  if (enable_transform)
+  {
+    u.swap_rows(i, j);
+  }
+  // *****************
+  // Givens equivalent
+  // *****************
+	l_givens.swap_rows(i,j); 
+	mu.swap_rows(i,j);
+	r.swap_rows(i,j);
+
+    if (move_lazy) {
+
+
+	  full_column_givens_row(i,j);
+	  for(int k = i+1; k < j; k++) {
+	  	full_column_givens_rotation(k,k+1);
+	  }
+	  compute_mu_and_r_columns(i,j);
+
+    } else {
+      recompute_givens_matrix(i,j);      
+
+    }
+
+  //if (always_recompute){
+  //  recompute_givens_matrix();
+ //}
+  
+}
+
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::move_row(int old_r, int new_r)
+{
+  //cerr << "Move " << old_r << " to " << new_r << " and n_known_rows = " << n_known_rows << endl;
+  FPLLL_DEBUG_CHECK(!cols_locked);
+  if (new_r < old_r)
+  {
+    FPLLL_DEBUG_CHECK(old_r < n_known_rows);
+    b.rotate_right(new_r, old_r);
+
+    if (enable_transform)
+    {
+      u.rotate_right(new_r, old_r);
+      if (enable_inverse_transform)
+        u_inv_t.rotate_right(new_r, old_r);
+    }
+
+    l_givens.rotate_right(new_r,old_r); 
+
+    mu.rotate_right(new_r,old_r);
+    r.rotate_right(new_r,old_r);
+
+
+    if (enable_row_expo) {
+      rotate(row_expo.begin() + new_r, row_expo.begin() + old_r, row_expo.begin() + old_r + 1);
+
+    }
+
+
+    if (move_lazy) {
+      full_column_givens_row(new_r,old_r);
+      compute_mu_and_r_columns(new_r,old_r);
+      lazy_row_start = min(new_r,lazy_row_start);
+    } else {
+      recompute_givens_matrix(new_r,n_known_rows);      
+
+    }
+
+
+
+  }
+  else if (new_r > old_r)
+  {
+  	//throw std::runtime_error("Wrong order of rotation!");
+
+    b.rotate_left(old_r, new_r);
+    if (enable_transform)
+    {
+      u.rotate_left(old_r, new_r);
+      if (enable_inverse_transform)
+        u_inv_t.rotate_left(old_r, new_r);
+    }
+
+
+
+
+    l_givens.rotate_left(old_r, new_r);
+    mu.rotate_left(old_r, new_r);
+    r.rotate_left(old_r, new_r);
+    if (enable_row_expo) {    
+      rotate(row_expo.begin() + old_r, row_expo.begin() + old_r + 1, row_expo.begin() + new_r + 1);
+    }
+
+    if (move_lazy) {
+      for(int i = old_r; i < new_r; i++)
+        full_column_givens_row(i,i+1);
+
+      compute_mu_and_r_columns(old_r,new_r);
+      lazy_row_start = min(old_r,lazy_row_start);
+
+    } else {
+      recompute_givens_matrix(old_r,n_known_rows);      
+    }
+
+  }
+
+    if (new_r >= n_known_rows)
+    {
+      if (old_r < n_known_rows)
+      {
+        n_known_rows--;
+      }
+    }
+
+
+  
+}
+
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::size_increased()
+{
+
+  if (d > alloc_dim)
+  {
+
+      mu.resize(d, b.get_cols());
+      l_givens.resize(d, b.get_cols());
+   	  r.resize(d, b.get_cols());
+   	  bf.resize(b.get_rows(),b.get_cols());
+   	  gf.resize(b.get_rows(),b.get_rows()); 
+      if (enable_row_expo)
+      {
+        row_expo.resize(d);
+      } 
+      ops_s.resize(d,b.get_cols());
+      ops_c.resize(d,b.get_cols());
+      //lazy_row_c.resize(1,b.get_cols());
+      //lazy_row_s.resize(1,b.get_cols());
+      alloc_dim = d;      
+  }
+
+}
+
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::row_op_end(int first, int last)
+{
+#ifdef DEBUG
+  FPLLL_DEBUG_CHECK(row_op_first == first && row_op_last == last);
+  row_op_first = row_op_last = -1;
+#endif
+}
+
+template <class ZT, class FT> void MatGSOGivens<ZT, FT>::discover_row()
+{
+  FPLLL_DEBUG_CHECK(n_known_rows < d);
+  FPLLL_DEBUG_CHECK(!(cols_locked));
+  n_known_rows++;
+
+}
+
+
+
+
+template class MatGSOGivens<Z_NR<long>, FP_NR<double>>;
+template class MatGSOGivens<Z_NR<double>, FP_NR<double>>;
+template class MatGSOGivens<Z_NR<mpz_t>, FP_NR<double>>;
+
+#ifdef FPLLL_WITH_LONG_DOUBLE
+template class MatGSOGivens<Z_NR<long>, FP_NR<long double>>;
+template class MatGSOGivens<Z_NR<double>, FP_NR<long double>>;
+template class MatGSOGivens<Z_NR<mpz_t>, FP_NR<long double>>;
+
+#endif
+
+#ifdef FPLLL_WITH_QD
+template class MatGSOGivens<Z_NR<long>, FP_NR<dd_real>>;
+template class MatGSOGivens<Z_NR<double>, FP_NR<dd_real>>;
+template class MatGSOGivens<Z_NR<mpz_t>, FP_NR<dd_real>>;
+
+template class MatGSOGivens<Z_NR<long>, FP_NR<qd_real>>;
+template class MatGSOGivens<Z_NR<double>, FP_NR<qd_real>>;
+template class MatGSOGivens<Z_NR<mpz_t>, FP_NR<qd_real>>;
+#endif
+
+#ifdef FPLLL_WITH_DPE
+template class MatGSOGivens<Z_NR<long>, FP_NR<dpe_t>>;
+template class MatGSOGivens<Z_NR<double>, FP_NR<dpe_t>>;
+template class MatGSOGivens<Z_NR<mpz_t>, FP_NR<dpe_t>>;
+#endif
+
+template class MatGSOGivens<Z_NR<long>, FP_NR<mpfr_t>>;
+template class MatGSOGivens<Z_NR<double>, FP_NR<mpfr_t>>;
+template class MatGSOGivens<Z_NR<mpz_t>, FP_NR<mpfr_t>>;
+
+FPLLL_END_NAMESPACE

--- a/fplll/gso_givens.h
+++ b/fplll/gso_givens.h
@@ -1,0 +1,462 @@
+/* Copyright (C) 2005-2008 Damien Stehle.
+   Copyright (C) 2007 David Cade.
+   Copyright (C) 2011 Xavier Pujol.
+
+   This file is part of fplll. fplll is free software: you
+   can redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License as published by the Free Software Foundation,
+   either version 2.1 of the License, or (at your option) any later version.
+
+   fplll is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with fplll. If not, see <http://www.gnu.org/licenses/>. */
+
+#ifndef FPLLL_GSOGIVENS_H
+#define FPLLL_GSOGIVENS_H
+
+#include "gso_interface.h"
+#include "nr/matrix.h"
+
+
+FPLLL_BEGIN_NAMESPACE
+
+
+
+/**
+ * MatGSOGivens provides an interface for performing elementary operations on a basis
+ * and computing its Gram matrix and its Gram-Schmidt orthogonalization.
+ * The Gram-Schmidt coefficients are computed on demand. The object keeps track
+ * of which coefficients are valid after each row operation.
+ */
+template <class ZT, class FT> class MatGSOGivens : public MatGSOInterface<ZT, FT>
+{
+public:
+  using MatGSOInterface<ZT, FT>::d;
+  using MatGSOInterface<ZT, FT>::n_known_rows;
+  using MatGSOInterface<ZT, FT>::n_source_rows;
+  using MatGSOInterface<ZT, FT>::u;
+  using MatGSOInterface<ZT, FT>::enable_transform;
+  //using MatGSOInterface<ZT, FT>::cols_locked;  // maybe scratch.
+  //using MatGSOInterface<ZT, FT>::recomputation_count;
+  //using MatGSOInterface<ZT, FT>::gso_valid_cols;
+  using MatGSOInterface<ZT, FT>::enable_inverse_transform;
+  using MatGSOInterface<ZT, FT>::u_inv_t;
+  //using MatGSOInterface<ZT, FT>::sym_g;
+  using MatGSOInterface<ZT, FT>::mu;
+  using MatGSOInterface<ZT, FT>::r;
+  using MatGSOInterface<ZT, FT>::ztmp1;
+  using MatGSOInterface<ZT, FT>::ztmp2;
+  using MatGSOInterface<ZT, FT>::row_op_force_long;
+  using MatGSOInterface<ZT, FT>::alloc_dim;
+  using MatGSOInterface<ZT, FT>::get_mu;
+  using MatGSOInterface<ZT, FT>::get_r;
+  //using MatGSOInterface<ZT, FT>::gptr;
+  //using MatGSOInterface<ZT, FT>::invalidate_gso_row;
+  using MatGSOInterface<ZT, FT>::gf;
+  using MatGSOInterface<ZT, FT>::bf;
+  using MatGSOInterface<ZT, FT>::discover_all_rows;
+  //using MatGSOInterface<ZT, FT>::init_row_size;
+  using MatGSOInterface<ZT, FT>::enable_row_expo;
+  using MatGSOInterface<ZT, FT>::row_expo;
+  //using MatGSOInterface<ZT, FT>::n_known_cols;
+  using MatGSOInterface<ZT, FT>::tmp_col_expo;
+
+  using MatGSOInterface<ZT, FT>::remove_last_row;
+  using MatGSOInterface<ZT, FT>::print_mu_r_g;
+  //using MatGSOInterface<ZT, FT>::update_gso;
+  //using MatGSOInterface<ZT, FT>::update_gso_row;
+  using MatGSOInterface<ZT, FT>::row_addmul;
+  //using MatGSOInterface<ZT, FT>::symmetrize_g;
+  using MatGSOInterface<ZT, FT>::ftmp1;
+  using MatGSOInterface<ZT, FT>::ftmp2;
+
+#ifdef DEBUG
+  /* Used only in debug mode. */
+  using MatGSOInterface<ZT, FT>::row_op_first;
+  using MatGSOInterface<ZT, FT>::row_op_last;
+  using MatGSOInterface<ZT, FT>::in_row_op_range;
+#endif
+
+
+
+
+  /**
+   * Constructor.
+   * The precision of FT must be defined before creating an instance of the
+   * class and must remain the same until the object is destroyed (or no longer
+   * needed).
+   * @param b
+   *   The matrix on which row operations are performed. It must not be empty.
+   * @param u
+   *   If u is not empty, operations on b are also done on u
+   *   (in this case both must have the same number of rows).
+   *   If u is initially the identity matrix, multiplying transform by the
+   *   initial basis gives the current basis.
+   * @param u_inv_t
+   *   Inverse transform (should be empty, which disables the computation, or
+   *   initialized with identity matrix). It works only if u is not empty.
+   * @param enable_int_gram
+   *   If true, coefficients of the Gram matrix are computed with exact integer
+   *   arithmetic (type ZT). Otherwise, they are computed in floating-point
+   *   (type FT). Note that when exact arithmetic is used, all coefficients of
+   *   the first n_known_rows are continuously updated, whereas in floating-point,
+   *   they are computed only on-demand. This option cannot be enabled if
+   *   enable_row_expo=true.
+   * @param enable_row_expo
+   *   If true, each row of b is normalized by a power of 2 before doing
+   *   conversion to floating-point, which hopefully avoids some overflows.
+   *   This option cannot be enabled if enable_int_gram=true and works only
+   *   with FT=double and FT=long double. It is useless and MUST NOT be used
+   *   for FT=dpe or FT=mpfr_t.
+   * @param row_op_force_long
+   *   Affects the behaviour of row_addmul(_we).
+   *   See the documentation of row_addmul.
+   */
+  MatGSOGivens(Matrix<ZT> &arg_b, Matrix<ZT> &arg_u, Matrix<ZT> &arg_uinv_t, int flags)
+      : MatGSOInterface<ZT, FT>(arg_u, arg_uinv_t, flags), b(arg_b), full_lazy(flags & GSO_GIVENS_FULL_LAZY), 
+       move_lazy(flags & (GSO_GIVENS_MOVE_LAZY | GSO_GIVENS_FULL_LAZY)), // also be move-lazy when you are full-lazy
+       always_recompute(flags & GSO_GIVENS_RECOMPUTE_AFTER_SIZERED)
+
+  {
+    //FPLLL_DEBUG_CHECK(!(enable_int_gram && enable_row_expo));
+    //
+    if (enable_row_expo)
+    {
+      tmp_col_expo.resize(b.get_cols());
+    }
+    d = b.get_rows();
+    // No row-exponents in Givens yet
+    /*
+    if (enable_row_expo)
+    {
+      tmp_col_expo.resize(b.get_cols());
+    }
+    */
+    size_increased();
+    lazy_row_start = d;
+
+    //initialize_l_givens_matrix();
+
+
+#ifdef DEBUG
+    row_op_first = row_op_last = -1;
+#endif
+  }
+
+public:
+
+
+  bool is_currently_lazy = false;
+  int lazy_row_start;
+
+  /**
+   * Basis of the lattice
+   */
+
+  Matrix<ZT> &b;
+  bool full_lazy;  
+  bool move_lazy;
+
+  bool always_recompute;  
+
+
+
+  Matrix<FT> l_givens;
+  //Matrix<FT> r_givens;
+  //Matrix<FT> mu_givens;
+
+  Matrix<FT> ops_c;
+  Matrix<FT> ops_s;
+
+
+
+  //long int ops_counter;
+
+  //irtual inline const FT &get_l_exp(int i, int j, long &expo) final;
+  //virtual inline const FT &get_l_exp(int i, int j) final;
+  virtual inline  FT &get_l(FT &f, int i, int j) final;
+
+  virtual inline  Matrix<ZT> &get_basis() final;
+
+  virtual inline long get_max_exp_of_b();
+  virtual inline bool b_row_is_zero(int i);
+  virtual inline int get_cols_of_b();
+  virtual inline int get_rows_of_b();
+  virtual inline void negate_row_of_b(int i);
+
+  virtual inline void create_rows(int n_new_rows);
+  virtual inline void remove_last_rows(int n_removed_rows);
+
+  virtual void move_row(int old_r, int new_r);
+
+  virtual void row_op_end(int first, int last) final;
+
+
+    void add_operation(FT c, FT s , int row, int col);
+    //void recompute_givens_operations(MatGSOGivens<ZT,FT> &m, int start_row, int end_row);
+    //void empty(int row);
+
+
+
+  // For givens rotations
+  void copy_b_to_l_givens(int row);
+  void apply_givens_operations(int row);
+  //void apply_givens_operations(int row_start, int row_end);
+
+  //void triangularize(int row_start, int row_end);
+
+  void givens_row(int row);
+  void givens_row(int row, int rightmost_nonzero_entry);
+  void virtual_givens_rotation(int row, int col, FT c, FT s);
+  void givens_rotation(int row, int col);
+  void compute_mu_and_r(int row);
+  void compute_mu_and_r_columns(int starting_column, int last_column);
+
+  void full_column_givens_rotation(int row, int col);
+  void full_column_givens_row(int row, int rightmost_nonzero_entry);
+  void recompute_givens_matrix(int last_row);
+    void recompute_givens_matrix(int start_row, int last_row);
+ // void normalize_givens_row(int row);
+//  void initialize_l_givens_matrix();
+//  void givens_rotation(int col_i, int col_j, int row_k);
+//  void givens_row_reduction(int row_k, int rightmost_nonzero_entry );
+
+//void compute_mu_and_r_columns(int starting_column, int last_column);
+
+
+
+  //void numerical_accuracy();
+
+  //virtual void recompute_givens_matrix();
+
+  //inline void compute_mu_and_r_column(int column);
+
+  /**
+   * Updates r(i, j) and mu(i, j) if needed for all j in [0, last_j].
+   * All coefficients of r and mu above the i-th row in columns
+   * [0, min(last_j, i - 1)] must be valid.
+   * If i=n_known_rows, n_known_rows is increased by one.
+   */
+  bool real_update_gso_row(int i);
+
+  virtual bool update_gso_row(int i, int last_j) final;
+
+  virtual inline bool update_gso_row(int i) final;
+
+  virtual inline bool update_gso() final ;
+
+  virtual inline bool is_givens();
+
+  virtual void set_r(int i, int j, FT &f);
+
+  /**
+   * b[i] := b[i] + x * b[j].
+   * After one or several calls to row_addmul, row_op_end must be called.
+   * Special cases |x| &lt;= 1 and |x| &lt;= LONG_MAX are optimized.
+   * x should be an integer.
+   * If row_op_force_long=true, x is always converted to (2^expo * long) instead
+   * of (2^expo * ZT), which is faster if ZT=mpz_t but might lead to a loss of
+   * precision (in LLL, more Babai iterations are needed).
+   */
+  // --> moved to interface
+  // virtual inline void row_addmul(int i, int j, const FT &x);
+
+  /**
+   * b[i] := b[i] + x * 2^expo_add * b[j].
+   * After one or several calls to row_addmul_we, row_op_end must be called.
+   * Special cases |x| &lt;= 1 and |x| &lt;= LONG_MAX are optimized.
+   * x should be an integer.
+   * If row_op_force_long=true, x is always converted to (2^expo * long) instead
+   * of (2^expo * ZT), which is faster if ZT=mpz_t but might lead to a loss of
+   * precision (in LLL, more Babai iterations are needed).
+   */
+  virtual void row_addmul_we(int i, int j, const FT &x, long expo_add);
+
+  // b[i] += b[j] / b[i] -= b[j] (i > j)
+  virtual void row_add(int i, int j);
+  virtual void row_sub(int i, int j);
+
+  //  virtual inline void printparam(ostream &os);
+  virtual inline FT &get_gram(FT &f, int i, int j) final;
+
+  // b[i] <-> b[j] (i < j)
+  virtual void row_swap(int i, int j);
+
+private:
+
+
+
+  /* Allocates matrices and arrays whose size depends on d (all but tmp_col_expo).
+   When enable_int_gram=false, initializes bf. */
+  virtual void size_increased();
+
+  virtual void discover_row();
+
+  /* Upates the i-th row of bf. It does not invalidate anything, so the caller
+     must take into account that it might change row_expo. */
+  virtual void update_bf(int i);
+
+  /* Marks g(i, j) for all j <= i (but NOT for j > i) */
+  virtual void invalidate_gram_row(int i);
+
+  // b[i] <- b[i] + x * b[j] (i > j)
+  virtual void row_addmul_si(int i, int j, long x);
+  // b[i] <- b[i] + (2^expo * x) * b[j] (i > j)
+  virtual void row_addmul_si_2exp(int i, int j, long x, long expo);
+  virtual void row_addmul_2exp(int i, int j, const ZT &x, long expo);
+
+};
+template <class ZT, class FT> inline  Matrix<ZT> &MatGSOGivens<ZT, FT>::get_basis() {
+  return b;  
+}
+/*template <class ZT, class FT> inline void MatGSOGivens<ZT, FT>::compute_mu_and_r_column(int column) {
+	compute_mu_and_r_columns(column,column);
+}
+*/
+template <class ZT, class FT> inline long MatGSOGivens<ZT, FT>::get_max_exp_of_b()
+{
+  return b.get_max_exp();
+}
+
+template <class ZT, class FT> inline bool MatGSOGivens<ZT, FT>::b_row_is_zero(int i)
+{
+  return b[i].is_zero();
+}
+template <class ZT, class FT> inline int MatGSOGivens<ZT, FT>::get_cols_of_b() { return b.get_cols(); }
+
+template <class ZT, class FT> inline int MatGSOGivens<ZT, FT>::get_rows_of_b() { return b.get_rows(); }
+
+template <class ZT, class FT> inline void MatGSOGivens<ZT, FT>::negate_row_of_b(int i)
+{
+
+  for (int j = 0; j < get_cols_of_b(); j++)
+  {
+    b[i][j].neg(b[i][j]);
+    // TODO Here some Givens-thing?
+  }
+  
+}
+
+template <class ZT, class FT> inline FT &MatGSOGivens<ZT, FT>::get_l(FT &f, int i, int j)
+{
+  f = l_givens(i,j);
+  return f;
+}
+
+/*
+template <class ZT, class FT>
+inline const FT &MatGSOGivens<ZT, FT>::get_l_exp(int i, int j, long &expo)
+{
+  FPLLL_DEBUG_CHECK(i >= 0 && i < n_known_rows && j >= 0 && j < gso_valid_cols[i] &&
+                    !in_row_op_range(i));
+  if (enable_row_expo)
+    expo = row_expo[i]; // + row_expo[j];
+  else
+    expo = 0;
+  return l_givens(i, j);
+}
+
+template <class ZT, class FT> inline const FT &MatGSOGivens<ZT, FT>::get_l_exp(int i, int j)
+{
+  return l_givens(i, j);
+}
+
+*/
+
+template <class ZT, class FT> inline FT &MatGSOGivens<ZT, FT>::get_gram(FT &f, int i, int j)
+{
+  FPLLL_DEBUG_CHECK(i >= 0 && i < n_known_rows && j >= 0 && j <= i && j < n_source_rows &&
+                    !in_row_op_range(i));
+
+    // TODO this was lazy before.
+    update_bf(i);
+    if (i != j) 
+    {
+      update_bf(j);
+    }
+    bf[i].dot_product(gf(i, j), bf[j], b.get_cols());
+    
+    f = gf(i, j);
+
+  return f;
+}
+
+
+template <class ZT, class FT> inline bool MatGSOGivens<ZT,FT>::is_givens(){
+  return true;
+}
+
+
+template <class ZT, class FT> inline void MatGSOGivens<ZT, FT>::create_rows(int n_new_rows)
+{
+  FPLLL_DEBUG_CHECK(!cols_locked);
+  int old_d = d;
+  d += n_new_rows;
+  b.set_rows(d);
+  for (int i = old_d; i < d; i++)
+  {
+    for (int j = 0; j < b.get_cols(); j++)
+    {
+      b[i][j] = 0;
+    }
+  }
+
+
+
+  if (enable_transform)
+  {
+    u.set_rows(d);
+    for (int i = old_d; i < d; i++)
+      for (int j = 0; j < u.get_cols(); j++)
+        u[i][j]  = 0;
+  }
+  size_increased();   // Givens matrix will be appended here
+  if (n_known_rows == old_d)
+    discover_all_rows();
+}
+
+template <class ZT, class FT> inline bool MatGSOGivens<ZT, FT>::update_gso_row(int i)
+{
+  return update_gso_row(i, i);
+}
+
+template <class ZT, class FT> inline bool MatGSOGivens<ZT, FT>::update_gso()
+{
+
+    for (int i = 0; i < d; i++)
+    {
+      if (!update_gso_row(i))
+        return false;
+    }
+  
+  return true;
+}
+
+template <class ZT, class FT> inline void MatGSOGivens<ZT, FT>::remove_last_rows(int n_removed_rows)
+{
+  FPLLL_DEBUG_CHECK(!cols_locked && d >= n_removed_rows);
+  d -= n_removed_rows;
+  n_known_rows  = min(n_known_rows, d);
+  n_source_rows = n_known_rows;
+  b.set_rows(d);
+
+  ops_c.set_rows(d);
+  ops_s.set_rows(d);
+  if (enable_transform)
+    u.set_rows(d);
+}
+
+template <class ZT, class FT> inline void MatGSOGivens<ZT, FT>::set_r(int i, int j, FT &f)
+{
+  FPLLL_DEBUG_CHECK(i >= 0 && i < n_known_rows && j >= 0 );
+  r(i, j) = f;
+}
+
+
+FPLLL_END_NAMESPACE
+
+#endif

--- a/fplll/gso_interface.h
+++ b/fplll/gso_interface.h
@@ -27,7 +27,15 @@ enum MatGSOInterfaceFlags
   GSO_DEFAULT       = 0,
   GSO_INT_GRAM      = 1,
   GSO_ROW_EXPO      = 2,
-  GSO_OP_FORCE_LONG = 4
+  GSO_OP_FORCE_LONG = 4,
+  GSO_GIVENS_MOVE_LAZY = 8,  	// Does not recompute after `row_swap` or `move_row`
+  GSO_GIVENS_FULL_LAZY = 16, 	// Does not recompute at all. Numerically unstable.
+  GSO_GIVENS_RECOMPUTE_AFTER_SIZERED = 32  // This is the *least* lazy approach. Recomputes after every size reduction.
+
+  // Givens GSO is standard lazy after size reductions [doesn't recompute from the basis].
+  // If GSO_GIVENS_MOVE_LAZY is on, it is also lazy after `row_swap` and `move_row`. Reasonable numerically unstable, relatively fast.
+  // If GSO_GIVENS_FULL_LAZY is on, it doesn't do recomputations from the basis at all. This is numerically very unstable. Very fast.
+  // If GSO_GIVENS_RECOMPUTE_AFTER_SIZERED is on, it does recompute after size reductions. This is most stable, but very slow.
 };
 
 /**
@@ -166,7 +174,7 @@ public:
    * Must be called after a sequence of row_addmul(_we). This invalidates the
    * i-th line of the GSO.
    */
-  void row_op_end(int first, int last);
+  virtual void row_op_end(int first, int last);
 
   /**
    * Returns Gram matrix coefficients (0 &lt;= i &lt; n_known_rows and
@@ -267,7 +275,7 @@ public:
    * [0, min(last_j, i - 1)] must be valid.
    * If i=n_known_rows, n_known_rows is increased by one.
    */
-  bool update_gso_row(int i, int last_j);
+  virtual bool update_gso_row(int i, int last_j);
 
   /**
    * Updates r(i, j) and mu(i, j) if needed for all j.
@@ -292,7 +300,7 @@ public:
    * are computed by the algorithm. They are set directly to avoid double
    * computation.
    */
-  void set_r(int i, int j, FT &f);
+  virtual void set_r(int i, int j, FT &f);
 
   /**
    * Row old_r becomes row new_r and intermediate rows are shifted.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -37,7 +37,7 @@ AM_CPPFLAGS = -I$(TOPSRCDIR) -I$(TOPSRCDIR)/fplll -I$(TOPBUILDDIR) -DTESTDATADIR
 STAGEDIR := $(realpath -s $(TOPBUILDDIR)/.libs)
 AM_LDFLAGS = -L$(STAGEDIR) -Wl,-rpath,$(STAGEDIR) -lfplll -no-install $(LIBQD_LIBADD)
 
-TESTS = test_nr test_lll test_cvp test_svp test_bkz test_pruner test_sieve test_gso test_lll_gram
+TESTS = test_lll_givens test_nr test_lll test_cvp test_svp test_bkz test_pruner test_sieve test_gso test_lll_gram test_benchmark
 
 test_pruner_LDADD=$(LIBGMP) -lmpfr $(LIBQD_LIBADD)
 test_sieve_LDADD=$(LIBGMP) -lmpfr $(LIBQD_LIBADD)
@@ -51,5 +51,7 @@ test_pruner_SOURCES = test_pruner.cpp
 test_sieve_SOURCES = test_sieve.cpp
 test_gso_SOURCES = test_gso.cpp
 test_lll_gram_SOURCES = test_lll_gram.cpp
+test_lll_givens_SOURCES = test_lll_givens.cpp
+test_benchmark_SOURCES = test_benchmark.cpp
 
 check_PROGRAMS = $(TESTS)

--- a/tests/test_benchmark.cpp
+++ b/tests/test_benchmark.cpp
@@ -1,0 +1,119 @@
+/* Copyright (C) 2015 Martin Albrecht
+
+   This file is part of fplll. fplll is free software: you
+   can redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License as published by the Free Software Foundation,
+   either version 2.1 of the License, or (at your option) any later version.
+
+   fplll is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with fplll. If not, see <http://www.gnu.org/licenses/>. */
+
+#include <cstring>
+#include <stdlib.h>     /* srand, rand */
+#include <gso.h>
+#include <gso_gram.h>
+#include <gso_interface.h>
+#include <gso_givens.h>
+#include <nr/matrix.h>
+#include <test_utils.h>
+//#include <random>
+
+using namespace std;
+using namespace fplll;
+
+#ifndef TESTDATADIR
+#define TESTDATADIR ".."
+#endif
+
+
+template<class ZT, class FT> int benchmark(Matrix<ZT> A)
+{ 
+
+  Matrix<ZT> B,U,UT;
+  int rowsA = A.get_rows();
+  int colsA = A.get_cols();
+
+  B.resize(rowsA,colsA);
+
+
+  for(int i = 0; i < rowsA; i++) {
+    for(int j = 0; j < colsA; j++) {
+        B(i,j) = A(i,j);
+    }
+  }
+
+  MatGSO<ZT, FT> M(A, U, UT, GSO_ROW_EXPO);
+  MatGSOGivens<ZT, FT> M_givens(B, U, UT,  GSO_ROW_EXPO | GSO_GIVENS_MOVE_LAZY );
+  LLLReduction<ZT, FT> LLLObj(M, LLL_DEF_DELTA, LLL_DEF_ETA, LLL_VERBOSE);  
+  LLLReduction<ZT, FT> LLLObj_givens(M_givens, LLL_DEF_DELTA, LLL_DEF_ETA, LLL_VERBOSE);
+
+  cerr << "Givens" << endl;
+  LLLObj_givens.lll();
+
+  cerr << "GSO" << endl;  
+  LLLObj.lll();  
+
+  M.update_gso();
+  M_givens.update_gso();
+
+
+  int is_reduced = is_lll_reduced<ZT, FT>(M, LLL_DEF_DELTA, LLL_DEF_ETA);
+
+  int is_reduced_givens = is_lll_reduced<ZT, FT>(M_givens, LLL_DEF_DELTA, LLL_DEF_ETA);
+
+    if (is_reduced != 1)
+    {
+      cerr << "::::::::::::::The basis GSO-object is not LLL-reduced after calling LLL\n";
+      return 1;
+    }
+    if (is_reduced_givens != 1)
+    {
+      cerr << ":::::::::::::::The givens GSO-object is not LLL-reduced after calling LLL\n";
+      return 1;
+    }
+
+return 0;
+
+
+}
+
+
+template <class ZT, class FT> int test_int_rel(int d, int b)
+{
+  ZZ_mat<ZT> A;
+  A.resize(d,d+1);
+  A.gen_intrel(b);
+
+  return benchmark<Z_NR<ZT>, FT>(A);
+}
+
+
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+  ZZ_mat<mpz_t> A;
+  int status = 0;
+
+  int sequence_length = 8;
+  int dimension_sequence[8] = {8, 8, 40, 100, 128, 140, 160, 200};
+  int bitsize_sequence[8] = {2000, 200000, 1600, 10000, 10000, 10000, 16000, 20000};
+  for(int i = 0; i < sequence_length; i++)
+    test_int_rel<mpz_t, FP_NR<double>>(dimension_sequence[i], bitsize_sequence[i]);
+
+  if (status == 0)
+  {
+    cerr << "All tests passed." << endl;
+    return 0;
+  }
+  else
+  {
+    return -1;
+  }
+
+  return 0;
+}

--- a/tests/test_lll_givens.cpp
+++ b/tests/test_lll_givens.cpp
@@ -1,0 +1,285 @@
+/* Copyright (C) 2015 Martin Albrecht
+
+   This file is part of fplll. fplll is free software: you
+   can redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License as published by the Free Software Foundation,
+   either version 2.1 of the License, or (at your option) any later version.
+
+   fplll is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with fplll. If not, see <http://www.gnu.org/licenses/>. */
+
+#include <cstring>
+#include <fplll.h>
+#include <gso.h>
+#include <gso_gram.h>
+#include <gso_interface.h>
+#include <gso_givens.h>
+#include <lll.h>
+#include <test_utils.h>
+
+using namespace std;
+using namespace fplll;
+
+#ifndef TESTDATADIR
+#define TESTDATADIR ".."
+#endif
+
+template <class ZT, class FT> int is_already_reduced(ZZ_mat<ZT> &A)
+{
+  ZZ_mat<ZT> U;
+  ZZ_mat<ZT> UT;
+
+  MatGSO<Z_NR<ZT>, FP_NR<FT>> M(A, U, UT, 0);
+  MatGSOGivens<Z_NR<ZT>, FP_NR<FT>> M2(A, U, UT, 0);
+
+
+
+
+  int is_reduced  = is_lll_reduced<Z_NR<ZT>, FP_NR<FT>>(M, LLL_DEF_DELTA, LLL_DEF_ETA);
+  int is_greduced = is_lll_reduced<Z_NR<ZT>, FP_NR<FT>>(M2, LLL_DEF_DELTA, LLL_DEF_ETA);
+  if (is_reduced)
+    cerr << "is_lll_reduced reports success when it should not" << endl;
+  if (is_greduced)
+    cerr << "is_lll_greduced reports success when it should not" << endl;
+  return (is_reduced || is_greduced);
+}
+
+/**
+   @brief Tests whether LLL applied on A is equivalent to LLLGram applied on G = A*A^T
+
+   @param A basis matrix of a lattice
+   @return zero on success
+*/
+
+template <class ZT, class FT> int test_lll(ZZ_mat<ZT> &A)
+{
+
+  ZZ_mat<ZT> U;
+  ZZ_mat<ZT> UT;
+
+  // _______________________________________________
+  // -----------------------------------------------
+  // Create copy of A.
+
+  ZZ_mat<ZT> A2;
+  int r = A.r;
+  int c = A.c;
+  A2.resize(r, c);
+  for (int i = 0; i < r; i++)
+  {
+    for (int j = 0; j < c; j++)
+    {
+      A2(i,j) = A(i,j);
+    }
+  }
+  // ------------------------------------------------
+  // ************************************************
+
+  // _______________________________________________
+  // -----------------------------------------------
+  // Create a MatGSO-object M (basis gso) for A
+  // and a MatGSOGram-object Mgram (gram gso) for G.
+
+  
+  MatGSO<Z_NR<ZT>, FP_NR<FT>> M(A, U, UT, 0);
+  //M.update_gso();
+  MatGSOGivens<Z_NR<ZT>, FP_NR<FT>> MGivens(A2, U, UT, GSO_GIVENS_FULL_LAZY);
+  //MGivens.update_gso();
+
+  // ------------------------------------------------
+  // ************************************************
+
+  // _________________________________________________
+  // -------------------------------------------------
+  // Test whether A  is not already LLL-reduced.
+  if (is_already_reduced<ZT, FT>(A))
+  {
+    cerr << "The matrices are already LLL-reduced";
+    return 1;
+  }
+
+
+  // ------------------------------------------------
+  // ************************************************
+
+  // _________________________________________________
+  // -------------------------------------------------
+  // Make two LLLObjects. One of the basis MatGSO-object M
+  // one of the MatGSO-givens object MGivens.
+  LLLReduction<Z_NR<ZT>, FP_NR<FT>> LLLObj(M, LLL_DEF_DELTA, LLL_DEF_ETA, LLL_VERBOSE);
+  LLLReduction<Z_NR<ZT>, FP_NR<FT>> LLLObjgram(MGivens, LLL_DEF_DELTA, LLL_DEF_ETA, LLL_VERBOSE);
+
+
+  // and LLL reduce both objects
+  LLLObj.lll();
+  LLLObjgram.lll();
+
+
+  cerr << "OK, LL reduction with dimension " << MGivens.d << " ok.";
+  // ------------------------------------------------
+  // ************************************************
+
+  // _________________________________________________
+  // -------------------------------------------------
+  // Check whether M and MGivens are really reduced after LLL reduction
+  int is_reduced  = is_lll_reduced<Z_NR<ZT>, FP_NR<FT>>(M, LLL_DEF_DELTA, LLL_DEF_ETA);
+
+
+  MatGSO<Z_NR<ZT>, FP_NR<FT>> M2(MGivens.b, U, UT, 1);
+  int is_greduced = is_lll_reduced<Z_NR<ZT>, FP_NR<FT>>(M2, LLL_DEF_DELTA, LLL_DEF_ETA);
+
+  if (is_reduced != 1 || is_greduced != 1)
+  {
+    if (is_reduced != 1)
+    {
+      cerr << "The basis GSO-object is not LLL-reduced after calling LLL\n";
+    }
+    if (is_greduced != 1)
+    {
+      cerr << "The givens GSO-object is not LLL-reduced after calling LLL\n";
+    }
+    return 1;
+  }
+  // ------------------------------------------------
+  // ************************************************
+
+
+  // Test whether G_reduced = G
+  for (int i = 0; i < r; i++)
+  {
+    for (int j = 0; j < c; j++)
+    {
+      if (M.b(i, j) != MGivens.b(i, j))
+      {
+        cerr << "Warning: the reductions are different at place (" << i << "," << j << ")" << endl << endl;
+        cerr << M.b[i] << endl << endl;
+        cerr << MGivens.b[i] << endl << endl;
+
+
+        return 0;
+      }
+    }
+  }
+  
+
+
+  // Return 0 on success.
+  return 0;
+}
+
+template <class ZT, class FT> int test_filename(const char *input_filename)
+{
+  ZZ_mat<ZT> A;
+  int status = 0;
+  status |= read_matrix(A, input_filename);
+  status |= test_lll<ZT, FT>(A);
+  return status;
+}
+
+/**
+   @brief Construct d × (d+1) integer relations matrix with bit size b and test LLL.
+
+   @param d                dimension
+   @param b                bit size
+
+   @return zero on success
+*/
+
+template <class ZT, class FT> int test_int_rel(int d, int b)
+{
+  ZZ_mat<ZT> A;
+  A.resize(d, d + 1);
+  A.gen_intrel(b);
+  return test_lll<ZT, FT>(A);
+}
+
+int main(int /*argc*/, char ** /*argv*/)
+{
+
+  int status = 0;
+
+  status |= test_filename<mpz_t, double>(TESTDATADIR "/tests/lattices/example2_in");
+  status |= test_filename<mpz_t, double>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice");
+  status |= test_filename<mpz_t, double>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice2");
+  status |= test_filename<mpz_t, double>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice3");
+  status |= test_filename<mpz_t, double>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice4");
+  status |= test_filename<mpz_t, double>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice5");
+  status |= test_int_rel<mpz_t, double>(50, 20);
+  status |= test_int_rel<mpz_t, double>(40, 10);
+
+  //status |= test_int_rel<mpz_t, double>(250,20);
+
+  status |= test_filename<mpz_t, mpfr_t>(TESTDATADIR "/tests/lattices/example2_in");
+  status |= test_filename<mpz_t, mpfr_t>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice");
+  status |= test_filename<mpz_t, mpfr_t>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice2");
+  status |= test_filename<mpz_t, mpfr_t>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice3");
+  status |= test_filename<mpz_t, mpfr_t>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice4");
+  status |= test_filename<mpz_t, mpfr_t>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice5");
+  status |= test_int_rel<mpz_t, mpfr_t>(50, 20);
+  status |= test_int_rel<mpz_t, mpfr_t>(40, 10);
+  
+
+#ifdef FPLLL_WITH_LONG_DOUBLE
+  status |= test_filename<mpz_t, long double>(TESTDATADIR "/tests/lattices/example2_in");
+  status |= test_filename<mpz_t, long double>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice");
+  status |=
+      test_filename<mpz_t, long double>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice2");
+  status |=
+      test_filename<mpz_t, long double>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice3");
+  status |=
+      test_filename<mpz_t, long double>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice4");
+  status |=
+      test_filename<mpz_t, long double>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice5");
+  status |= test_int_rel<mpz_t, long double>(50, 20);
+  status |= test_int_rel<mpz_t, long double>(40, 10);
+
+#endif
+#ifdef FPLLL_WITH_QD
+  status |= test_filename<mpz_t, dd_real>(TESTDATADIR "/tests/lattices/example2_in");
+  status |= test_filename<mpz_t, dd_real>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice");
+  status |= test_filename<mpz_t, dd_real>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice2");
+  status |= test_filename<mpz_t, dd_real>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice3");
+  status |= test_filename<mpz_t, dd_real>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice4");
+  status |= test_filename<mpz_t, dd_real>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice5");
+  status |= test_int_rel<mpz_t, dd_real>(50, 20);
+  status |= test_int_rel<mpz_t, dd_real>(40, 10);
+
+  status |= test_filename<mpz_t, qd_real>(TESTDATADIR "/tests/lattices/example2_in");
+  status |= test_filename<mpz_t, qd_real>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice");
+  status |= test_filename<mpz_t, qd_real>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice2");
+  status |= test_filename<mpz_t, qd_real>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice3");
+  status |= test_filename<mpz_t, qd_real>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice4");
+  status |= test_filename<mpz_t, qd_real>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice5");
+  status |= test_int_rel<mpz_t, qd_real>(50, 20);
+  status |= test_int_rel<mpz_t, qd_real>(40, 10);
+
+#endif
+#ifdef FPLLL_WITH_DPE
+  status |= test_filename<mpz_t, dpe_t>(TESTDATADIR "/tests/lattices/example2_in");
+  status |= test_filename<mpz_t, dpe_t>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice");
+  status |= test_filename<mpz_t, dpe_t>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice2");
+  status |= test_filename<mpz_t, dpe_t>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice3");
+  status |= test_filename<mpz_t, dpe_t>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice4");
+  status |= test_filename<mpz_t, dpe_t>(TESTDATADIR "/tests/lattices/example_cvp_in_lattice5");
+  status |= test_int_rel<mpz_t, dpe_t>(50, 20);
+  status |= test_int_rel<mpz_t, dpe_t>(40, 10);
+
+#endif
+
+  if (status == 0)
+  {
+    cerr << "All tests passed." << endl;
+    return 0;
+  }
+  else
+  {
+    return -1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
- Added `gso_givens.h` and `gso_givens.cpp`.
- Added `test_lll_givens.cpp` in the tests folder.

The givens GSO class should be compatible with LLL, but not  (yet) with Wrapper. I didn't check whether BKZ can run on this givens GSO class.

Issues:
- Operations on the Givens-matrix `l_givens` are mainly Givens-rotations, which are column operations. @lducas suggested to store the transpose of `l_givens` instead of `l_givens` itself. However, then the 'lazy' size-reductions occur as column operations. So, the main question is: Should we store `l_givens` or the transpose of it? What is the fastest way?
- Discovering rows could be amortized by discovering multiple rows at a time, and not telling it to the interface.
- How do the different lazyness approaches influence the numerical stability? 