### PR TITLE
Suppress warnings reported by Wextra

### DIFF
--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -80,7 +80,7 @@ void BKZReduction<ZT, FT>::rerandomize_block(int min_row, int max_row, int densi
 }
 
 template <class ZT, class FT>
-const PruningParams &BKZReduction<ZT, FT>::get_pruning(int kappa, int block_size,
+const PruningParams &BKZReduction<ZT, FT>::get_pruning(int kappa, unsigned int block_size,
                                                        const BKZParam &par) const
 {
 
@@ -98,7 +98,8 @@ const PruningParams &BKZReduction<ZT, FT>::get_pruning(int kappa, int block_size
 }
 
 template <class ZT, class FT>
-bool BKZReduction<ZT, FT>::svp_preprocessing(int kappa, int block_size, const BKZParam &param)
+bool BKZReduction<ZT, FT>::svp_preprocessing(int kappa, unsigned int block_size,
+                                             const BKZParam &param)
 {
   bool clean = true;
 

--- a/fplll/bkz.h
+++ b/fplll/bkz.h
@@ -115,7 +115,7 @@ public:
    *@returns
    *    false if it modified the basis, true otherwise
    */
-  bool svp_preprocessing(int kappa, int block_size, const BKZParam &param);
+  bool svp_preprocessing(int kappa, unsigned int block_size, const BKZParam &param);
 
   /**
    * @brief Inserts given (dual) vector into the basis
@@ -303,7 +303,7 @@ private:
 
   bool set_status(int new_status);
 
-  const PruningParams &get_pruning(int kappa, int block_size, const BKZParam &par) const;
+  const PruningParams &get_pruning(int kappa, unsigned int block_size, const BKZParam &par) const;
 
   // handles the general case of inserting a vector into the (dual) basis, i.e.
   // when none of the coefficients are \pm 1

--- a/fplll/enum/evaluator.cpp
+++ b/fplll/enum/evaluator.cpp
@@ -268,15 +268,14 @@ bool FastErrorBoundedEvaluator::get_max_error(FP_NR<mpfr_t> &max_error,
   return true;
 }
 
-bool ExactErrorBoundedEvaluator::get_max_error(FP_NR<mpfr_t> &max_error,
-                                               const FP_NR<mpfr_t> &last_partial_dist)
+bool ExactErrorBoundedEvaluator::get_max_error(FP_NR<mpfr_t> &max_error, const FP_NR<mpfr_t> &)
 {
   max_error = 0.0;
   return true;
 }
 
-void ExactErrorBoundedEvaluator::eval_sol(const vector<FP_NR<mpfr_t>> &new_sol_coord,
-                                          const enumf &new_partial_dist, enumf &max_dist)
+void ExactErrorBoundedEvaluator::eval_sol(const vector<FP_NR<mpfr_t>> &new_sol_coord, const enumf &,
+                                          enumf &max_dist)
 {
   int n = matrix.get_cols();
   Z_NR<mpz_t> new_sol_dist, coord;
@@ -315,7 +314,7 @@ void ExactErrorBoundedEvaluator::eval_sol(const vector<FP_NR<mpfr_t>> &new_sol_c
 
 void ExactErrorBoundedEvaluator::eval_sub_sol(int offset,
                                               const vector<FP_NR<mpfr_t>> &new_sub_sol_coord,
-                                              const enumf &sub_dist)
+                                              const enumf &)
 {
   Z_NR<mpz_t> minusone;
   minusone = -1;

--- a/fplll/gso_gram.cpp
+++ b/fplll/gso_gram.cpp
@@ -37,12 +37,12 @@ template <class ZT, class FT> void MatGSOGram<ZT, FT>::discover_row()
   gso_valid_cols[i] = 0;
 }
 
-template <class ZT, class FT> void MatGSOGram<ZT, FT>::update_bf(int i)
+template <class ZT, class FT> void MatGSOGram<ZT, FT>::update_bf(int)
 {
   // EMPTY
 }
 
-template <class ZT, class FT> void MatGSOGram<ZT, FT>::invalidate_gram_row(int i)
+template <class ZT, class FT> void MatGSOGram<ZT, FT>::invalidate_gram_row(int)
 {
   // EMPTY
 }

--- a/fplll/gso_gram.h
+++ b/fplll/gso_gram.h
@@ -69,9 +69,13 @@ public:
   using MatGSOInterface<ZT, FT>::in_row_op_range;
 #endif
 
-  MatGSOGram(Matrix<ZT> &arg_g, Matrix<ZT> &arg_u, Matrix<ZT> &arg_uinv_t, int flags)
-      : MatGSOInterface<ZT, FT>(arg_u, arg_uinv_t, GSO_INT_GRAM)
+  MatGSOGram(Matrix<ZT> &arg_g, Matrix<ZT> &arg_u, Matrix<ZT> &arg_uinv_t, int flags = GSO_INT_GRAM)
+      : MatGSOInterface<ZT, FT>(arg_u, arg_uinv_t, flags)
   {
+    if (flags != GSO_INT_GRAM)
+    {
+      throw std::invalid_argument("flags must be equal to GSO_INT_GRAM");
+    }
     gptr = &arg_g;
     if (gptr == nullptr)
     {

--- a/fplll/main.cpp
+++ b/fplll/main.cpp
@@ -120,7 +120,7 @@ void read_pruning_vector(const char *file_name, PruningParams &pr, int n)
         "File '" << file_name << "' should contain exactly " << n << " numbers");
 }
 
-template <class ZT> int bkz(Options &o, ZZ_mat<ZT> &b) { ABORT_MSG("mpz required for BKZ"); }
+template <class ZT> int bkz(Options &, ZZ_mat<ZT> &) { ABORT_MSG("mpz required for BKZ"); }
 
 template <> int bkz(Options &o, ZZ_mat<mpz_t> &b)
 {
@@ -194,7 +194,7 @@ template <> int bkz(Options &o, ZZ_mat<mpz_t> &b)
    Note: since we only force |mu_i,j| <= eta with eta > 0.5, the solution
    is not unique even for a generic matrix */
 
-template <class ZT> int hkz(Options &o, ZZ_mat<ZT> &b) { ABORT_MSG("mpz required for HKZ"); }
+template <class ZT> int hkz(Options &, ZZ_mat<ZT> &) { ABORT_MSG("mpz required for HKZ"); }
 
 template <> int hkz(Options &o, ZZ_mat<mpz_t> &b)
 {
@@ -225,7 +225,7 @@ template <> int hkz(Options &o, ZZ_mat<mpz_t> &b)
 
 /* Shortest vector problem and closest vector problem */
 
-template <class ZT> int svpcvp(Options &o, ZZ_mat<ZT> &b, const vector<Z_NR<ZT>> &target)
+template <class ZT> int svpcvp(Options &, ZZ_mat<ZT> &, const vector<Z_NR<ZT>> &target)
 {
   if (target.empty())
   {

--- a/fplll/nr/nr_FP_misc.inl
+++ b/fplll/nr/nr_FP_misc.inl
@@ -338,13 +338,13 @@ inline void FP_NR<qd_real>::get_z_exp_we(Z_NR<long>& a, long& expo, long expo_ad
 #ifdef FPLLL_WITH_ZDOUBLE
 /** get_z_exp_we (from dd_real to Z_NR<double>) */
 template<> template<>
-inline void FP_NR<dd_real>::get_z_exp_we(Z_NR<double>& a, long& expo, long expo_add) const {
+inline void FP_NR<dd_real>::get_z_exp_we(Z_NR<double>& a, long& expo, long) const {
   expo = 0;
   a = get_si();
 }
 /** get_z_exp_we (from qd_real to Z_NR<double>) */
 template<> template<>
-inline void FP_NR<qd_real>::get_z_exp_we(Z_NR<double>& a, long& expo, long expo_add) const {
+inline void FP_NR<qd_real>::get_z_exp_we(Z_NR<double>& a, long& expo, long) const {
   expo = 0;
   a = get_si();
 }

--- a/fplll/sieve/sieve_main.cpp
+++ b/fplll/sieve/sieve_main.cpp
@@ -72,6 +72,7 @@ int main(int argc, char **argv)
       alg = atoi(optarg);
       if (alg != 2 && alg != 3 && alg != 4)
         throw std::invalid_argument("only support 2-, 3- and 4-sieve");
+      break;
     case 'f':
       input_file_name = optarg;
       flag_file       = true;

--- a/fplll/wrapper.cpp
+++ b/fplll/wrapper.cpp
@@ -390,8 +390,8 @@ int lll_reduction_zf(ZZ_mat<ZT> &b, ZZ_mat<ZT> &u, ZZ_mat<ZT> &u_inv, double del
 }
 
 template <class ZT>
-int lll_reduction_wrapper(ZZ_mat<ZT> &b, ZZ_mat<ZT> &u, ZZ_mat<ZT> &u_inv, double delta, double eta,
-                          FloatType float_type, int precision, int flags)
+int lll_reduction_wrapper(ZZ_mat<ZT> &, ZZ_mat<ZT> &, ZZ_mat<ZT> &, double, double, FloatType, int,
+                          int)
 {
   FPLLL_ABORT("The wrapper method works only with integer type mpz");
   return RED_LLL_FAILURE;

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -183,7 +183,7 @@ int test_bkz_param_pruning(ZZ_mat<ZT> &A, const int block_size, int flags = BKZ_
    @return zero on success.
  */
 template <class ZT>
-int test_int_rel_bkz_dump_gso(int d, int b, const int block_size, FloatType float_type = FT_DEFAULT,
+int test_int_rel_bkz_dump_gso(int d, int b, const int block_size,
                               int flags = BKZ_DEFAULT | BKZ_DUMP_GSO)
 {
   ZZ_mat<ZT> A, B;
@@ -375,7 +375,7 @@ int main(int /*argc*/, char ** /*argv*/)
       test_filename<mpz_t>(TESTDATADIR "/tests/lattices/example_in", 10, FT_DOUBLE, BKZ_SLD_RED);
 
   // Test BKZ_DUMP_GSO
-  status |= test_int_rel_bkz_dump_gso<mpz_t>(50, 1000, 15, FT_MPFR, BKZ_DEFAULT | BKZ_DUMP_GSO);
+  status |= test_int_rel_bkz_dump_gso<mpz_t>(50, 1000, 15, BKZ_DEFAULT | BKZ_DUMP_GSO);
 
   if (status == 0)
   {

--- a/tests/test_gso.cpp
+++ b/tests/test_gso.cpp
@@ -197,8 +197,7 @@ template <class ZT, class FT> int test_filename(const char *input_filename)
    @return zero on success
 */
 
-template <class ZT, class FT>
-int test_int_rel(int d, int b, FloatType float_type = FT_DEFAULT, int prec = 0)
+template <class ZT, class FT> int test_int_rel(int d, int b)
 {
   ZZ_mat<ZT> A;
   A.resize(d, d + 1);

--- a/tests/test_nr.cpp
+++ b/tests/test_nr.cpp
@@ -86,7 +86,7 @@ template <class FT> int test_root()
   return status;
 }
 
-int main(int argc, char *argv[])
+int main()
 {
 
   int status = 0;

--- a/tests/test_pruner.cpp
+++ b/tests/test_pruner.cpp
@@ -509,7 +509,7 @@ template <class FT> int test_auto_prune(size_t n)
   return status;
 }
 
-int main(int argc, char *argv[])
+int main()
 {
   int status = 0;
 #ifdef FPLLL_WITH_QD

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -291,12 +291,10 @@ int test_filename(const char *input_filename, const char *output_filename,
 /**
    @brief Run SVP tests.
 
-   @param argc             ignored
-   @param argv             ignored
    @return
 */
 
-int main(int argc, char *argv[])
+int main()
 {
 
   int status = 0;


### PR DESCRIPTION
This PR tries to remove warnings reported by adding `-Wextra -DDEBUG` to the `CXXFLAGS` variable of the configuration of `fplll`.