### PR TITLE
Release 5.2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ matrix:
       - brew update
       - brew reinstall gmp
       - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then rm /usr/local/include/c++ ; fi
-      - brew install qd autoconf libtool clang-format
+      - brew install autoconf libtool clang-format
 
 install:
   - export CXX="$COMPILER"

--- a/Doxyfile
+++ b/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = "fplll"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 5.2.0
+PROJECT_NUMBER         = 5.2.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ(2.61)
-AC_INIT(fplll, 5.2.0)
+AC_INIT(fplll, 5.2.1)
 AC_CONFIG_SRCDIR([fplll/fplll.cpp])
 
 # cf http://comments.gmane.org/gmane.comp.sysutils.autoconf.general/15737
@@ -38,7 +38,7 @@ LT_INIT
 # 3. If interfaces were removed (breaks backward compatibility): increment
 #    current, and set both revision and age to zero.
 
-FPLLL_LT_CURRENT=4
+FPLLL_LT_CURRENT=5
 FPLLL_LT_REVISION=0
 FPLLL_LT_AGE=0
 


### PR DESCRIPTION
Hi all,

Fplll 5.2.1 was released on 18 May 2018 and is available at

https://github.com/fplll/fplll/releases/tag/5.2.1

This release is a bugfix release. Major changes in fplll-5.2.1 compared to fplll-5.2.0:

- [Possibly resolved the Gram bug](https://github.com/fplll/fplll/pull/349) by Koen de Boer
- [Fix Solaris issues](https://github.com/fplll/fplll/pull/348) by Jeroen Demeyer
- [Unify randomness on 32-bit and 64-bit systems](https://github.com/fplll/fplll/pull/345) by Martin Albrecht
- [Adding Windows 10 instructions to the readme](https://github.com/fplll/fplll/pull/337) by Thijs Laarhoven
- [Can use mpir instead of gmp](https://github.com/fplll/fplll/pull/335) by Laurent Grémy
- [Dot product](https://github.com/fplll/fplll/pull/326) by Laurent Grémy
- [make MatGSOGram.row_swap public](https://github.com/fplll/fplll/pull/325) by Martin Albrecht
- [dd wrapper](https://github.com/fplll/fplll/pull/322) by Gilles Villard

We also fixed various other issues, see
https://github.com/fplll/fplll/compare/5.2.0...5.2.1 for details.

The following people have contributed to this release (based on the link
above):

- Gilles Villard
- Jeroen Demeyer
- Koen de Boer
- Laurent Grémy
- Martin Albrecht
- Shi Bai
- Thijs Laarhoven

Please report issues at

https://github.com/fplll/fplll/issues

Cheers,
the maintainers