### PR TITLE
Remove Wcatch-value and unify way to check if files are read.

### DIFF
--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -274,7 +274,7 @@ int test_filename(const char *input_filename, const int block_size,
 {
   ZZ_mat<ZT> A, B;
   int status = 0;
-  status |= read_matrix(A, input_filename);
+  status |= read_file_process(A, input_filename);
   B = A;
   status |= test_bkz<ZT>(A, block_size, float_type, flags, prec);
   status |= test_bkz_param<ZT>(B, block_size);

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -274,7 +274,7 @@ int test_filename(const char *input_filename, const int block_size,
 {
   ZZ_mat<ZT> A, B;
   int status = 0;
-  status |= read_file_process(A, input_filename);
+  status |= read_file(A, input_filename);
   B = A;
   status |= test_bkz<ZT>(A, block_size, float_type, flags, prec);
   status |= test_bkz_param<ZT>(B, block_size);

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -89,13 +89,13 @@ int test_filename(const char *input_filename_lattice, const char *input_filename
 {
   ZZ_mat<ZT> A;
   int status = 0;
-  status |= read_file_process(A, input_filename_lattice);
+  status |= read_file(A, input_filename_lattice);
 
   vector<Z_NR<mpz_t>> t;
-  status |= read_file_process(t, input_filename_target);
+  status |= read_file(t, input_filename_target);
 
   vector<Z_NR<mpz_t>> b;
-  status |= read_file_process(b, output_filename);
+  status |= read_file(b, output_filename);
 
   status |= test_cvp<ZT>(A, t, b, method);
   return status;

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -89,13 +89,13 @@ int test_filename(const char *input_filename_lattice, const char *input_filename
 {
   ZZ_mat<ZT> A;
   int status = 0;
-  status |= read_matrix(A, input_filename_lattice);
+  status |= read_file_process(A, input_filename_lattice);
 
   vector<Z_NR<mpz_t>> t;
-  status |= read_vector(t, input_filename_target);
+  status |= read_file_process(t, input_filename_target);
 
   vector<Z_NR<mpz_t>> b;
-  status |= read_vector(b, output_filename);
+  status |= read_file_process(b, output_filename);
 
   status |= test_cvp<ZT>(A, t, b, method);
   return status;

--- a/tests/test_gso.cpp
+++ b/tests/test_gso.cpp
@@ -151,8 +151,8 @@ template <class ZT, class FT> int test_ggso(ZZ_mat<ZT> &A)
 template <class ZT, class FT> int test_filename(const char *input_filename)
 {
   ZZ_mat<ZT> A;
-  int status = read_file_process(A, input_filename);
-  // if status == 1, read_file_process fails.
+  int status = read_file(A, input_filename);
+  // if status == 1, read_file fails.
   if (status == 1)
   {
     return 1;

--- a/tests/test_gso.cpp
+++ b/tests/test_gso.cpp
@@ -151,8 +151,8 @@ template <class ZT, class FT> int test_ggso(ZZ_mat<ZT> &A)
 template <class ZT, class FT> int test_filename(const char *input_filename)
 {
   ZZ_mat<ZT> A;
-  int status = read_matrix(A, input_filename);
-  // if status == 1, read_matrix fails.
+  int status = read_file_process(A, input_filename);
+  // if status == 1, read_file_process fails.
   if (status == 1)
   {
     return 1;

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -119,7 +119,7 @@ int test_filename(const char *input_filename, LLLMethod method, FloatType float_
 {
   ZZ_mat<ZT> A;
   int status = 0;
-  status |= read_file_process(A, input_filename);
+  status |= read_file(A, input_filename);
   status |= test_lll<ZT>(A, method, float_type, flags, prec);
   return status;
 }

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -119,7 +119,7 @@ int test_filename(const char *input_filename, LLLMethod method, FloatType float_
 {
   ZZ_mat<ZT> A;
   int status = 0;
-  status |= read_matrix(A, input_filename);
+  status |= read_file_process(A, input_filename);
   status |= test_lll<ZT>(A, method, float_type, flags, prec);
   return status;
 }

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -179,7 +179,7 @@ template <class ZT, class FT> int test_filename(const char *input_filename)
 {
   ZZ_mat<ZT> A;
   int status = 0;
-  status |= read_matrix(A, input_filename);
+  status |= read_file_process(A, input_filename);
   status |= test_lll<ZT, FT>(A);
   return status;
 }

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -179,7 +179,7 @@ template <class ZT, class FT> int test_filename(const char *input_filename)
 {
   ZZ_mat<ZT> A;
   int status = 0;
-  status |= read_file_process(A, input_filename);
+  status |= read_file(A, input_filename);
   status |= test_lll<ZT, FT>(A);
   return status;
 }

--- a/tests/test_sieve.cpp
+++ b/tests/test_sieve.cpp
@@ -58,9 +58,9 @@ template <class ZT> int test_filename(const char *input_filename, const char *ou
 {
   ZZ_mat<ZT> A;
   int status = 0;
-  status |= read_file_process(A, input_filename);
+  status |= read_file(A, input_filename);
   vector<Z_NR<mpz_t>> b;
-  status |= read_file_process(b, output_filename);
+  status |= read_file(b, output_filename);
   status |= test_sieve<ZT>(A, b);
   return status;
 }

--- a/tests/test_sieve.cpp
+++ b/tests/test_sieve.cpp
@@ -58,9 +58,9 @@ template <class ZT> int test_filename(const char *input_filename, const char *ou
 {
   ZZ_mat<ZT> A;
   int status = 0;
-  status |= read_matrix(A, input_filename);
+  status |= read_file_process(A, input_filename);
   vector<Z_NR<mpz_t>> b;
-  status |= read_vector(b, output_filename);
+  status |= read_file_process(b, output_filename);
   status |= test_sieve<ZT>(A, b);
   return status;
 }

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -266,10 +266,10 @@ int test_filename(const char *input_filename, const char *output_filename,
 {
   ZZ_mat<ZT> A;
   int status = 0;
-  status |= read_file_process(A, input_filename);
+  status |= read_file(A, input_filename);
 
   vector<Z_NR<mpz_t>> b;
-  status |= read_file_process(b, output_filename);
+  status |= read_file(b, output_filename);
 
   switch (test)
   {

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -266,10 +266,10 @@ int test_filename(const char *input_filename, const char *output_filename,
 {
   ZZ_mat<ZT> A;
   int status = 0;
-  status |= read_matrix(A, input_filename);
+  status |= read_file_process(A, input_filename);
 
   vector<Z_NR<mpz_t>> b;
-  status |= read_vector(b, output_filename);
+  status |= read_file_process(b, output_filename);
 
   switch (test)
   {

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -5,47 +5,27 @@
 using namespace std;
 using namespace fplll;
 
-#define read_file(X, input_filename) {\
-  ifstream is;\
-  is.exceptions(std::ifstream::failbit | std::ifstream::badbit);\
-  try {\
-    is.open(input_filename);\
-    is >> X;\
-    is.close();\
-  }\
-  catch (const ifstream::failure&) {\
-    status = 1;\
-    cerr << "Error by reading " << input_filename << "." << endl;\
-  }\
-}
-
 /**
-   @brief Read matrix from `input_filename`.
+   @brief Read T from `input_filename`.
 
-   @param A matrix
+   @param X T (T is usually a ZZ_mat<ZT> or a vector<Z_NR<ZT>>
    @param input_filename
    @return zero if the file is correctly read, 1 otherwise.
 */
-template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
-{
+template <class T> int read_file_process(T &X, const char *input_filename) {
   int status = 0;
-  read_file(A, input_filename);
+  ifstream is;
+  is.exceptions(std::ifstream::failbit | std::ifstream::badbit);
+  try {
+    is.open(input_filename);
+    is >> X;
+    is.close();
+  }
+  catch (const ifstream::failure&) {
+    status = 1;
+    cerr << "Error by reading " << input_filename << "." << endl;
+  }
+
   return status;
 }
-
-/**
-   @brief Read vector from `input_filename` into `b`.
-
-   @param b                vector
-   @param input_filename   filename
-   @return zero if the file is correctly read, 1 otherwise.
-*/
-
-template <class ZT> int read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
-{
-  int status = 0;
-  read_file(b, input_filename);
-  return status;
-}
-
 #endif /* TEST_UTILS_H */

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -5,6 +5,20 @@
 using namespace std;
 using namespace fplll;
 
+#define read_file(X, input_filename) {\
+  ifstream is;\
+  is.exceptions(std::ifstream::failbit | std::ifstream::badbit);\
+  try {\
+    is.open(input_filename);\
+    is >> X;\
+    is.close();\
+  }\
+  catch (const ifstream::failure&) {\
+    status = 1;\
+    cerr << "Error by reading " << input_filename << "." << endl;\
+  }\
+}
+
 /**
    @brief Read matrix from `input_filename`.
 
@@ -15,13 +29,7 @@ using namespace fplll;
 template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 {
   int status = 0;
-  ifstream is(input_filename);
-  if (!is)
-  {
-    status = 1;
-    cerr << "Could not open file " << input_filename << "." << endl;
-  }  // throw std::runtime_error("could not open input file");
-  is >> A;
+  read_file(A, input_filename);
   return status;
 }
 
@@ -36,17 +44,7 @@ template <class ZT> int read_matrix(ZZ_mat<ZT> &A, const char *input_filename)
 template <class ZT> int read_vector(vector<Z_NR<ZT>> &b, const char *input_filename)
 {
   int status = 0;
-  ifstream is;
-  is.exceptions(std::ifstream::failbit | std::ifstream::badbit);
-  try {
-    is.open(input_filename);
-    is >> b;
-    is.close();
-  }
-  catch (ifstream::failure e) {
-    status = 1;
-    cerr << "Error by reading " << input_filename << "." << endl;
-  }
+  read_file(b, input_filename);
   return status;
 }
 

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -12,7 +12,7 @@ using namespace fplll;
    @param input_filename
    @return zero if the file is correctly read, 1 otherwise.
 */
-template <class T> int read_file_process(T &X, const char *input_filename) {
+template <class T> int read_file(T &X, const char *input_filename) {
   int status = 0;
   ifstream is;
   is.exceptions(std::ifstream::failbit | std::ifstream::badbit);


### PR DESCRIPTION
This commit removes the warnings produced by `-Wcatch-value`, probably enabled by default in gcc-8. This is also the occasion to use a unified version to check if the files are correctly read.