### PR TITLE
Fixing issue #362

### DIFF
--- a/fplll/bkz.h
+++ b/fplll/bkz.h
@@ -29,7 +29,7 @@ FPLLL_BEGIN_NAMESPACE
  * @brief Performs a heuristic check if BKZ can be terminated.
  *
  * Checks if the slope of the basis hasn't decreased in a while.
-*/
+ */
 template <class ZT, class FT> class BKZAutoAbort
 {
 public:
@@ -42,7 +42,7 @@ public:
    *    the number of vectors to check
    * @param start_row
    *    the starting point of the vectors to check
-  */
+   */
   BKZAutoAbort(MatGSO<ZT, FT> &m, int num_rows, int start_row = 0)
       : m(m), old_slope(numeric_limits<double>::max()), no_dec(-1), num_rows(num_rows),
         start_row(start_row)
@@ -78,12 +78,12 @@ private:
 };
 
 /**
-   * @brief The class performing block reduction.
-   *
-   * This class implements BKZ, SD-BKZ and Slide Reduction. For this
-   * it relies on the GSO, LLL, and Enumeration modules. It assumes
-   * that the basis is LLL reduced.
-**/
+ * @brief The class performing block reduction.
+ *
+ * This class implements BKZ, SD-BKZ and Slide Reduction. For this
+ * it relies on the GSO, LLL, and Enumeration modules. It assumes
+ * that the basis is LLL reduced.
+ **/
 template <class ZT, class FT> class BKZReduction
 {
   /**
@@ -160,7 +160,7 @@ public:
    *    flag specifying if the block is to be SVP or dual SVP reduced.
    * @returns
    *    false if it made progress, true otherwise
-  */
+   */
   bool svp_reduction(int kappa, int block_size, const BKZParam &param, bool dual = false);
 
   /**

--- a/fplll/enum/enumerate.cpp
+++ b/fplll/enum/enumerate.cpp
@@ -27,7 +27,7 @@ void EnumerationDyn<ZT, FT>::reset(enumf cur_dist, int cur_depth)
   int new_dim = cur_depth + 1;
 
   vector<enumxt> partial_sol(d - cur_depth - 1);
-  for (int i                       = cur_depth + 1; i < d; ++i)
+  for (int i = cur_depth + 1; i < d; ++i)
     partial_sol[i - cur_depth - 1] = x[i];
 
   FT new_dist = 0.0;
@@ -49,7 +49,7 @@ void EnumerationDyn<ZT, FT>::reset(enumf cur_dist, int cur_depth)
     {
       // FPLLL_TRACE("Saving it.");
       for (int i = 0; i < new_dim; ++i)
-        x[i]     = new_evaluator.begin()->second[i].get_d();
+        x[i] = new_evaluator.begin()->second[i].get_d();
       process_solution(sol_dist + cur_dist);
     }
   }
@@ -67,7 +67,7 @@ void EnumerationDyn<ZT, FT>::enumerate(int first, int last, FT &fmaxdist, long f
   target          = target_coord;
   if (last == -1)
     last = _gso.d;
-  d      = last - first;
+  d = last - first;
   fx.resize(d);
   FPLLL_CHECK(d < maxdim, "enumerate: dimension is too high");
   FPLLL_CHECK((solvingsvp || !dual), "CVP for dual not implemented! What does that even mean? ");
@@ -79,12 +79,12 @@ void EnumerationDyn<ZT, FT>::enumerate(int first, int last, FT &fmaxdist, long f
 
   if (solvingsvp)
   {
-    for (int i          = 0; i < d; ++i)
+    for (int i = 0; i < d; ++i)
       center_partsum[i] = 0.0;
   }
   else
   {
-    for (int i          = 0; i < d; ++i)
+    for (int i = 0; i < d; ++i)
       center_partsum[i] = target_coord[i + first].get_d();
   }
 
@@ -223,7 +223,7 @@ template <typename ZT, typename FT> void EnumerationDyn<ZT, FT>::set_bounds()
   }
   else
   {
-    for (int i          = 0; i < d; ++i)
+    for (int i = 0; i < d; ++i)
       partdistbounds[i] = pruning_bounds[i] * maxdist;
   }
 }
@@ -232,7 +232,7 @@ template <typename ZT, typename FT> void EnumerationDyn<ZT, FT>::process_solutio
 {
   FPLLL_TRACE("Sol dist: " << newmaxdist << " (nodes:" << nodes << ")");
   for (int j = 0; j < d; ++j)
-    fx[j]    = x[j];
+    fx[j] = x[j];
   _evaluator.eval_sol(fx, newmaxdist, maxdist);
 
   set_bounds();
@@ -242,9 +242,9 @@ template <typename ZT, typename FT>
 void EnumerationDyn<ZT, FT>::process_subsolution(int offset, enumf newdist)
 {
   for (int j = 0; j < offset; ++j)
-    fx[j]    = 0.0;
+    fx[j] = 0.0;
   for (int j = offset; j < d; ++j)
-    fx[j]    = x[j];
+    fx[j] = x[j];
   _evaluator.eval_sub_sol(offset, fx, newdist);
 }
 

--- a/fplll/enum/enumerate_base.cpp
+++ b/fplll/enum/enumerate_base.cpp
@@ -55,18 +55,18 @@ inline void EnumerationBase::enumerate_recursive(
     partdist[kk - 1] = newdist;
     if (dualenum)
     {
-      for (int j                   = center_partsum_begin[kk]; j > kk - 1; --j)
+      for (int j = center_partsum_begin[kk]; j > kk - 1; --j)
         center_partsums[kk - 1][j] = center_partsums[kk - 1][j + 1] - alpha[j] * mut[kk - 1][j];
     }
     else
     {
-      for (int j                   = center_partsum_begin[kk]; j > kk - 1; --j)
+      for (int j = center_partsum_begin[kk]; j > kk - 1; --j)
         center_partsums[kk - 1][j] = center_partsums[kk - 1][j + 1] - x[j] * mut[kk - 1][j];
     }
     if (center_partsum_begin[kk] > center_partsum_begin[kk - 1])
       center_partsum_begin[kk - 1] = center_partsum_begin[kk];
-    center_partsum_begin[kk]       = kk;
-    center[kk - 1]                 = center_partsums[kk - 1][kk];
+    center_partsum_begin[kk] = kk;
+    center[kk - 1]           = center_partsums[kk - 1][kk];
     roundto(x[kk - 1], center[kk - 1]);
     dx[kk - 1] = ddx[kk - 1] = (((int)(center[kk - 1] >= x[kk - 1]) & 1) << 1) - 1;
   }
@@ -105,7 +105,7 @@ inline void EnumerationBase::enumerate_recursive(
               center_partsums[kk - 1][kk - 1 + 1 + 1] - x[kk - 1 + 1] * mut[kk - 1][kk - 1 + 1];
         if (kk > center_partsum_begin[kk - 1])
           center_partsum_begin[kk - 1] = kk;
-        center[kk - 1]                 = center_partsums[kk - 1][kk - 1 + 1];
+        center[kk - 1] = center_partsums[kk - 1][kk - 1 + 1];
         roundto(x[kk - 1], center[kk - 1]);
         dx[kk - 1] = ddx[kk - 1] = (((int)(center[kk - 1] >= x[kk - 1]) & 1) << 1) - 1;
       }
@@ -136,7 +136,7 @@ inline void EnumerationBase::enumerate_recursive(
               center_partsums[kk - 1][kk - 1 + 1 + 1] - x[kk - 1 + 1] * mut[kk - 1][kk - 1 + 1];
         if (kk > center_partsum_begin[kk - 1])
           center_partsum_begin[kk - 1] = kk;
-        center[kk - 1]                 = center_partsums[kk - 1][kk - 1 + 1];
+        center[kk - 1] = center_partsums[kk - 1][kk - 1 + 1];
         roundto(x[kk - 1], center[kk - 1]);
         dx[kk - 1] = ddx[kk - 1] = (((int)(center[kk - 1] >= x[kk - 1]) & 1) << 1) - 1;
       }
@@ -231,12 +231,12 @@ template <bool dualenum, bool findsubsols, bool enable_reset> void EnumerationBa
       }
       if (dualenum)
       {
-        for (int j              = center_partsum_begin[k + 1]; j > k; --j)
+        for (int j = center_partsum_begin[k + 1]; j > k; --j)
           center_partsums[k][j] = center_partsums[k][j + 1] - alpha[j] * mut[k][j];
       }
       else
       {
-        for (int j              = center_partsum_begin[k + 1]; j > k; --j)
+        for (int j = center_partsum_begin[k + 1]; j > k; --j)
           center_partsums[k][j] = center_partsums[k][j + 1] - x[j] * mut[k][j];
       }
       center_partsum_begin[k]     = max(center_partsum_begin[k], center_partsum_begin[k + 1]);

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -33,8 +33,8 @@ inline void roundto(double &dest, const double &src) { dest = round(src); }
 
 /* config */
 #define MAXTEMPLATEDDIMENSION 80  // unused
-//#define FORCE_ENUM_INLINE // not recommended
-/* end config */
+  //#define FORCE_ENUM_INLINE // not recommended
+  /* end config */
 
 #ifndef __has_attribute
 #define __has_attribute(x) 0  // Compatibility with non - GCC/clang compilers.
@@ -120,8 +120,8 @@ protected:
 
   template <bool dualenum, bool findsubsols, bool enable_reset> void enumerate_loop();
 
-  virtual void reset(enumf, int) = 0;
-  virtual void process_solution(enumf newmaxdist) = 0;
+  virtual void reset(enumf, int)                              = 0;
+  virtual void process_solution(enumf newmaxdist)             = 0;
   virtual void process_subsolution(int offset, enumf newdist) = 0;
 
   int rounding_backup;

--- a/fplll/enum/enumerate_ext.cpp
+++ b/fplll/enum/enumerate_ext.cpp
@@ -112,12 +112,12 @@ void ExternalEnumeration<ZT, FT>::callback_set_config(enumf *mu, size_t mudim, b
 
   if (_pruning.empty())
   {
-    for (int i   = 0; i < _d; ++i)
+    for (int i = 0; i < _d; ++i)
       pruning[i] = 1.0;
   }
   else
   {
-    for (int i   = 0; i < _d; ++i)
+    for (int i = 0; i < _d; ++i)
       pruning[i] = _pruning[i];
   }
 }
@@ -126,7 +126,7 @@ template <typename ZT, typename FT>
 enumf ExternalEnumeration<ZT, FT>::callback_process_sol(enumf dist, enumf *sol)
 {
   for (int i = 0; i < _d; ++i)
-    _fx[i]   = sol[i];
+    _fx[i] = sol[i];
   _evaluator.eval_sol(_fx, dist, _maxdist);
   return _maxdist;
 }
@@ -135,9 +135,9 @@ template <typename ZT, typename FT>
 void ExternalEnumeration<ZT, FT>::callback_process_subsol(enumf dist, enumf *subsol, int offset)
 {
   for (int i = 0; i < offset; ++i)
-    _fx[i]   = 0.0;
+    _fx[i] = 0.0;
   for (int i = offset; i < _d; ++i)
-    _fx[i]   = subsol[i];
+    _fx[i] = subsol[i];
   _evaluator.eval_sub_sol(offset, _fx, dist);
 }
 

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -74,7 +74,7 @@ typedef uint64_t(extenum_fc_enumerate)(int dim, enumf maxdist,
                                        std::function<extenum_cb_process_sol> cbsol,
                                        std::function<extenum_cb_process_subsol> cbsubsol,
                                        bool dual /*=false*/, bool findsubsols /*=false*/
-                                       );
+);
 
 // set & get external enumerator (nullptr => disabled)
 void set_external_enumerator(std::function<extenum_fc_enumerate> extenum = nullptr);

--- a/fplll/enum/evaluator.cpp
+++ b/fplll/enum/evaluator.cpp
@@ -239,7 +239,7 @@ void FastErrorBoundedEvaluator::eval_sub_sol(int offset,
   {
     sub_solutions[offset].first  = dist;
     sub_solutions[offset].second = new_sub_sol_coord;
-    for (int i                        = 0; i < offset; ++i)
+    for (int i = 0; i < offset; ++i)
       sub_solutions[offset].second[i] = 0.0;
   }
 }
@@ -345,7 +345,7 @@ void ExactErrorBoundedEvaluator::eval_sub_sol(int offset,
   {
     sub_solutions[offset].first  = subdist;
     sub_solutions[offset].second = new_sub_sol_coord;
-    for (int i                        = 0; i < offset; ++i)
+    for (int i = 0; i < offset; ++i)
       sub_solutions[offset].second[i] = 0.0;
   }
 }

--- a/fplll/enum/evaluator.h
+++ b/fplll/enum/evaluator.h
@@ -46,7 +46,7 @@ enum EvaluatorStrategy
    * EVALSTRATEGY_FIRST_N_SOLUTIONS
    *   The enumeration bound is not updated. As soon as max_sols are found, enumeration
    *   stops.
-  */
+   */
   EVALSTRATEGY_BEST_N_SOLUTIONS          = 0,
   EVALSTRATEGY_OPPORTUNISTIC_N_SOLUTIONS = 1,
   EVALSTRATEGY_FIRST_N_SOLUTIONS         = 2
@@ -154,10 +154,10 @@ protected:
 };
 
 /**
-* Simple solution evaluator which provides a result without error bound.
-* The same instance can be used for several calls to enumerate on different
-* problems.
-*/
+ * Simple solution evaluator which provides a result without error bound.
+ * The same instance can be used for several calls to enumerate on different
+ * problems.
+ */
 template <class FT> class FastEvaluator : public Evaluator<FT>
 {
 public:
@@ -196,7 +196,7 @@ public:
     {
       sub_solutions[offset].first  = dist;
       sub_solutions[offset].second = new_sub_sol_coord;
-      for (int i                        = 0; i < offset; ++i)
+      for (int i = 0; i < offset; ++i)
         sub_solutions[offset].second[i] = 0.0;
     }
   }

--- a/fplll/gso.h
+++ b/fplll/gso.h
@@ -274,7 +274,7 @@ template <class ZT, class FT> inline void MatGSO<ZT, FT>::create_rows(int n_new_
     u.set_rows(d);
     for (int i = old_d; i < d; i++)
       for (int j = 0; j < u.get_cols(); j++)
-        u[i][j]  = 0;
+        u[i][j] = 0;
   }
   size_increased();
   if (n_known_rows == old_d)

--- a/fplll/gso_gram.h
+++ b/fplll/gso_gram.h
@@ -245,7 +245,7 @@ template <class ZT, class FT> inline void MatGSOGram<ZT, FT>::create_rows(int n_
     u.set_rows(d);
     for (int i = old_d; i < d; i++)
       for (int j = 0; j < u.get_cols(); j++)
-        u[i][j]  = 0;
+        u[i][j] = 0;
   }
   size_increased();
   if (n_known_rows == old_d)

--- a/fplll/gso_interface.h
+++ b/fplll/gso_interface.h
@@ -124,7 +124,7 @@ public:
    * Returns maximum exponent of b. In the gram
    * version it returns a half times the
    * maximum exponent of g.
-  */
+   */
   virtual long get_max_exp_of_b() = 0;
 
   /** Returns true if the ith row
@@ -147,8 +147,8 @@ public:
   virtual int get_rows_of_b() = 0;
 
   /** Negates the ith row of b. Needed
-    * by dbkz_postprocessing.
-    */
+   * by dbkz_postprocessing.
+   */
   virtual void negate_row_of_b(int i) = 0;
 
   /**
@@ -460,8 +460,8 @@ public:
 
 protected:
   /** Allocates matrices and arrays whose size depends on d (all but tmp_col_expo).
-    * When enable_int_gram=false, initializes bf.
-    */
+   * When enable_int_gram=false, initializes bf.
+   */
   virtual void size_increased() = 0;
 
   /* Increases known rows and invalidates the last
@@ -475,8 +475,8 @@ protected:
   // Marks mu(i, j) and r(i, j) as invalid for j >= new_valid_cols
   void invalidate_gso_row(int i, int new_valid_cols = 0);
   /*  Upates the i-th row of bf. It does not invalidate anything, so the caller
-    * must take into account that it might change row_expo.
-    */
+   * must take into account that it might change row_expo.
+   */
   virtual void update_bf(int i) = 0;
   /* Marks g(i, j) for all j <= i (but NOT for j > i) */
   virtual void invalidate_gram_row(int i) = 0;
@@ -546,10 +546,10 @@ protected:
 
 public:
   /** Replaced the gram matrix by a pointer. In the gso-class
-    * there is also a matrix g, and in the constructor gptr is
-    * defined to be equal to &g. In the ggso-class a gram matrix
-    * is given (arg_g), and gptr is defined as &arg_g.
-    */
+   * there is also a matrix g, and in the constructor gptr is
+   * defined to be equal to &g. In the ggso-class a gram matrix
+   * is given (arg_g), and gptr is defined as &arg_g.
+   */
 
   /* Gram matrix (dot products of basis vectors, lower triangular matrix)
    g(i, j) is valid if 0 <= i < n_known_rows and j <= i */

--- a/fplll/hlll.cpp
+++ b/fplll/hlll.cpp
@@ -398,9 +398,9 @@ template <class ZT, class FT> bool HLLLReduction<ZT, FT>::verify_size_reduction(
 // avoid to return it.
 #ifdef DEBUG
     m.get_R(ftmp1, kappa, i, expo1);  // R(kappa, i) = ftmp1 * 2^expo1
-#else   // DEBUG
+#else                                 // DEBUG
     m.get_R(ftmp1, kappa, i);  // R(kappa, i) = ftmp1 * 2^expo0
-#endif  // DEBUG
+#endif                                // DEBUG
 
     FPLLL_DEBUG_CHECK(expo0 == expo1);  // Since R[kappa] and b[kappa] share the same row_expo.
     ftmp1.abs(ftmp1);

--- a/fplll/hlll.h
+++ b/fplll/hlll.h
@@ -55,6 +55,7 @@ public:
 
   // Get the status of the computation
   inline int get_status() { return status; }
+
 private:
   // Paramters to (delta, eta, theta) hlll-reduce the basis b in m.
   FT delta, eta, theta;

--- a/fplll/householder.cpp
+++ b/fplll/householder.cpp
@@ -173,7 +173,7 @@ template <class ZT, class FT> void MatHouseholder<ZT, FT>::update_R(int i, bool 
       // Copy R into R_history
       // TODO: this is a row operation. Can try to copy R(i, j..n-1) directly in
       // R_history[i][j](j..n-1).
-      for (k               = j; k < n; k++)
+      for (k = j; k < n; k++)
         R_history[i][j][k] = R(i, k);
     }
 

--- a/fplll/lll.cpp
+++ b/fplll/lll.cpp
@@ -76,8 +76,8 @@ bool LLLReduction<ZT, FT>::lll(int kappa_min, int kappa_start, int kappa_end,
   }
 
   long long iter, max_iter;
-  max_iter = static_cast<long long>(
-      d - 2 * d * (d + 1) * ((m.get_max_exp_of_b() + 3) / std::log(delta.get_d())));
+  max_iter = static_cast<long long>(d - 2 * d * (d + 1) *
+                                            ((m.get_max_exp_of_b() + 3) / std::log(delta.get_d())));
 
   for (iter = 0; iter < max_iter && kappa < kappa_end - zeros; iter++)
   {

--- a/fplll/main.cpp
+++ b/fplll/main.cpp
@@ -104,8 +104,8 @@ void read_pruning_vector(const char *file_name, PruningParams &pr, int n)
   for (int i = 0; i <= n && fscanf(file, "%lf", &x) == 1; i++)
   {
     pr.coefficients.push_back(x);
-    CHECK(x > 0 && x <= 1, "Number " << x << " in file '" << file_name
-                                     << "' is not in the interval (0,1]");
+    CHECK(x > 0 && x <= 1,
+          "Number " << x << " in file '" << file_name << "' is not in the interval (0,1]");
     if (i == 0)
     {
       CHECK(x == 1, "The first number in file '" << file_name << "' should be 1");
@@ -754,8 +754,9 @@ void read_options(int argc, char **argv, Options &o)
     }
     else if (argv[ac][0] == '-')
     {
-      ABORT_MSG("invalid option '" << argv[ac] << "'.\n"
-                                                  "Try '"
+      ABORT_MSG("invalid option '" << argv[ac]
+                                   << "'.\n"
+                                      "Try '"
                                    << argv[0] << " --help' for more information.");
     }
     else

--- a/fplll/nr/matrix.cpp
+++ b/fplll/nr/matrix.cpp
@@ -264,11 +264,11 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_simdioph(int bits, int bits2)
     matrix[0][i].randb(bits);
   for (i = 1; i < r; i++)
   {
-    for (j         = 1; j < i; j++)
+    for (j = 1; j < i; j++)
       matrix[j][i] = 0;
-    matrix[i][i]   = 1;
+    matrix[i][i] = 1;
     matrix[i][i].mul_2si(matrix[i][i], bits);
-    for (j         = i + 1; j < c; j++)
+    for (j = i + 1; j < c; j++)
       matrix[j][i] = 0;
   }
 }
@@ -304,7 +304,7 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_ntrulike(int bits)
 
   q.randb(bits);
   if (q.sgn() == 0)
-    q  = 1;
+    q = 1;
   h[0] = 0;
   for (i = 1; i < d; i++)
   {
@@ -318,26 +318,26 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_ntrulike(int bits)
   // I in A00
   for (i = 0; i < d; i++)
   {
-    for (j         = 0; j < i; j++)
+    for (j = 0; j < i; j++)
       matrix[i][j] = 0;
-    matrix[i][i]   = 1;
-    for (j         = i + 1; j < d; j++)
+    matrix[i][i] = 1;
+    for (j = i + 1; j < d; j++)
       matrix[i][j] = 0;
   }
 
   // 0 in A10
   for (i = d; i < r; i++)
   {
-    for (j         = 0; j < d; j++)
+    for (j = 0; j < d; j++)
       matrix[i][j] = 0;
   }
   // qI in A11
   for (i = d; i < r; i++)
   {
-    for (j         = d; j < i; j++)
+    for (j = d; j < i; j++)
       matrix[i][j] = 0;
-    matrix[i][i]   = q;
-    for (j         = i + 1; j < c; j++)
+    matrix[i][i] = q;
+    for (j = i + 1; j < c; j++)
       matrix[i][j] = 0;
   }
   // H in A01
@@ -386,26 +386,26 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_ntrulike_withq(int q)
   // I in A00
   for (i = 0; i < d; i++)
   {
-    for (j         = 0; j < i; j++)
+    for (j = 0; j < i; j++)
       matrix[i][j] = 0;
-    matrix[i][i]   = 1;
-    for (j         = i + 1; j < d; j++)
+    matrix[i][i] = 1;
+    for (j = i + 1; j < d; j++)
       matrix[i][j] = 0;
   }
 
   // 0 in A10
   for (i = d; i < r; i++)
   {
-    for (j         = 0; j < d; j++)
+    for (j = 0; j < d; j++)
       matrix[i][j] = 0;
   }
   // qI in A11
   for (i = d; i < r; i++)
   {
-    for (j         = d; j < i; j++)
+    for (j = d; j < i; j++)
       matrix[i][j] = 0;
-    matrix[i][i]   = q2;
-    for (j         = i + 1; j < c; j++)
+    matrix[i][i] = q2;
+    for (j = i + 1; j < c; j++)
       matrix[i][j] = 0;
   }
   // H in A01
@@ -451,16 +451,16 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_ntrulike2(int bits)
 
   for (i = 0; i < d; i++)
   {
-    for (j         = 0; j < c; j++)
+    for (j = 0; j < c; j++)
       matrix[i][j] = 0;
   }
 
-  for (i         = 0; i < d; i++)
+  for (i = 0; i < d; i++)
     matrix[i][i] = q;
   for (i = d; i < r; i++)
-    for (j         = d; j < c; j++)
+    for (j = d; j < c; j++)
       matrix[i][j] = 0;
-  for (i         = d; i < c; i++)
+  for (i = d; i < c; i++)
     matrix[i][i] = 1;
 
   for (i = d; i < r; i++)
@@ -507,16 +507,16 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_ntrulike2_withq(int q)
 
   for (i = 0; i < d; i++)
   {
-    for (j         = 0; j < c; j++)
+    for (j = 0; j < c; j++)
       matrix[i][j] = 0;
   }
 
-  for (i         = 0; i < d; i++)
+  for (i = 0; i < d; i++)
     matrix[i][i] = q2;
   for (i = d; i < r; i++)
-    for (j         = d; j < c; j++)
+    for (j = d; j < c; j++)
       matrix[i][j] = 0;
-  for (i         = d; i < c; i++)
+  for (i = d; i < c; i++)
     matrix[i][i] = 1;
 
   for (i = d; i < r; i++)
@@ -546,10 +546,10 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_qary(int k, Z_NR<ZT> &q)
   }
 
   for (i = 0; i < d - k; i++)
-    for (j         = 0; j < d - k; j++)
+    for (j = 0; j < d - k; j++)
       matrix[i][j] = 0;
 
-  for (i         = 0; i < d - k; i++)
+  for (i = 0; i < d - k; i++)
     matrix[i][i] = 1;
 
   for (i = 0; i < d - k; i++)
@@ -557,10 +557,10 @@ template <class ZT> inline void ZZ_mat<ZT>::gen_qary(int k, Z_NR<ZT> &q)
       matrix[i][j].randm(q);
 
   for (i = d - k; i < d; i++)
-    for (j         = 0; j < d; j++)
+    for (j = 0; j < d; j++)
       matrix[i][j] = 0;
 
-  for (i         = d - k; i < d; i++)
+  for (i = d - k; i < d; i++)
     matrix[i][i] = q;
 }
 

--- a/fplll/nr/matrix.h
+++ b/fplll/nr/matrix.h
@@ -268,7 +268,7 @@ public:
   void gen_identity(int d)
   {
     gen_zero(d, d);
-    for (int i     = 0; i < d; i++)
+    for (int i = 0; i < d; i++)
       matrix[i][i] = 1;
   }
   /** Generate an augmented matrix of random coefficients for the first column */
@@ -296,7 +296,7 @@ public:
   void gen_ntrulike2_withq(int q);
 
   /** Construct a matrix ``[[I,H],[0,Iq]]`` where ``H`` is uniform mod q, of dimensions (n-k) x k.
-  */
+   */
 
   void gen_qary(int k, Z_NR<ZT> &q);
 

--- a/fplll/pruner/pruner.cpp
+++ b/fplll/pruner/pruner.cpp
@@ -48,7 +48,7 @@ int run_pruner_f(ZZ_mat<mpz_t> &b, int sel_ft, int prune_start, int prune_end,
     end = b.get_rows();
   if (prune_pre_nodes <= 1)
     prune_pre_nodes = 1;
-  int block_size    = end - start;
+  int block_size = end - start;
 
   PruningParams pruning;
   vector<double> r;

--- a/fplll/pruner/pruner_optimize_tc.cpp
+++ b/fplll/pruner/pruner_optimize_tc.cpp
@@ -256,7 +256,7 @@ void Pruner<FT>::optimize_coefficients_local_adjust_decr_single(/*io*/ vector<do
     {
       // cerr << " improved from " << old_cf << " to  " << new_cf << endl;
       if (slices[ind] < 1024)
-        slices[ind]     = slices[ind] * 1.05;
+        slices[ind] = slices[ind] * 1.05;
       consecutive_fails = 0;
     }
 
@@ -624,7 +624,7 @@ template <class FT> int Pruner<FT>::nelder_mead_step(/*io*/ vec &b)
   {
     mini = maxi = maxi2 = 0;
     for (int i = 0; i < dn; ++i)
-      bo[i]    = bs[0][i];
+      bo[i] = bs[0][i];
     ////////////////
     // step 1. and 2. : Order and centroid
     ////////////////
@@ -702,7 +702,7 @@ template <class FT> int Pruner<FT>::nelder_mead_step(/*io*/ vec &b)
     vec br(dn);  // reflected point
     FT fr;       // Value at the reflexion point
     for (int i = 0; i < dn; ++i)
-      br[i]    = bo[i] + ND_ALPHA * (bo[i] - bs[maxi][i]);
+      br[i] = bo[i] + ND_ALPHA * (bo[i] - bs[maxi][i]);
     enforce(br);
     fr = target_function(br);
     if (verbosity)
@@ -730,7 +730,7 @@ template <class FT> int Pruner<FT>::nelder_mead_step(/*io*/ vec &b)
       vec be(dn);
       FT fe;
       for (int i = 0; i < dn; ++i)
-        be[i]    = bo[i] + ND_GAMMA * (br[i] - bo[i]);
+        be[i] = bo[i] + ND_GAMMA * (br[i] - bo[i]);
       enforce(be);
       fe = target_function(be);
       if (verbosity)
@@ -771,7 +771,7 @@ template <class FT> int Pruner<FT>::nelder_mead_step(/*io*/ vec &b)
     vec bc(dn);
     FT fc;
     for (int i = 0; i < dn; ++i)
-      bc[i]    = bo[i] + ND_RHO * (bs[maxi][i] - bo[i]);
+      bc[i] = bo[i] + ND_RHO * (bs[maxi][i] - bo[i]);
     enforce(bc);
     fc = target_function(bc);
     if (verbosity)

--- a/fplll/sieve/sampler_basic.cpp
+++ b/fplll/sieve/sampler_basic.cpp
@@ -124,9 +124,9 @@ template <class ZT, class F> NumVect<Z_NR<ZT>> KleinSampler<ZT, F>::sample()
   Z_NR<ZT> tmpz;
 
   for (int i = 0; i < nc; i++)
-    vec[i]   = 0.0;
+    vec[i] = 0.0;
   for (int i = 0; i < nr; i++)
-    ci[i]    = 0.0;
+    ci[i] = 0.0;
 
   for (int i = nr - 1; i >= 0; i--)
   {

--- a/fplll/sieve/sieve_gauss_2sieve.cpp
+++ b/fplll/sieve/sieve_gauss_2sieve.cpp
@@ -137,7 +137,7 @@ template <class ZT, class F> bool GaussSieve<ZT, F>::run_2sieve()
     /* sieve current_point */
     current_norm = update_p_2reduce(current_point);
 
-// print_list(List);
+    // print_list(List);
 
 #ifdef REDUCE_TIMING
     gettimeofday(&time2, 0);

--- a/fplll/sieve/sieve_gauss_str.h
+++ b/fplll/sieve/sieve_gauss_str.h
@@ -127,14 +127,14 @@ template <class ZT> inline bool half_2reduce(ListPoint<ZT> *p1, const ListPoint<
   t.mul_ui(t, 2);
   t.mul(t, dot);
   (p1->norm).sub(s, t);
-/*
-if (debug) {
-  cout << "[debug]  p1new = " << p1->v << endl;
-  cout << "[debug]  |p1new| = " << p1->norm << endl;
-  cout << "[debug]  |v| = " << p2->norm << endl;
-     if (p1->norm <= p2->norm && p1->norm != 0)
-     exit(1);
-}*/
+  /*
+  if (debug) {
+    cout << "[debug]  p1new = " << p1->v << endl;
+    cout << "[debug]  |p1new| = " << p1->norm << endl;
+    cout << "[debug]  |v| = " << p2->norm << endl;
+       if (p1->norm <= p2->norm && p1->norm != 0)
+       exit(1);
+  }*/
 
 #if 0
   gettimeofday(&time, 0);

--- a/fplll/svpcvp.cpp
+++ b/fplll/svpcvp.cpp
@@ -428,8 +428,8 @@ int closest_vector(ZZ_mat<mpz_t> &b, const vector<Z_NR<mpz_t>> &int_target,
           max_index = cur;
         }
       }
-      for (cur                        = max_index; cur < previous_max_index; ++cur)
-        max_indices[cur]              = max_index;
+      for (cur = max_index; cur < previous_max_index; ++cur)
+        max_indices[cur] = max_index;
       max_indices[previous_max_index] = previous_max_index;
       previous_max_index              = max_index;
       --max_index;

--- a/fplll/util.cpp
+++ b/fplll/util.cpp
@@ -55,7 +55,7 @@ static int compute_min_prec(double &rho, int d, double delta, double eta, double
     // eta - 0.5 is an exact fp operation
     if (f_epsilon > eta - 0.5)
       f_epsilon = eta - 0.5;
-    tmp1        = 1.0;
+    tmp1 = 1.0;
     tmp1.sub(tmp1, f_delta, GMP_RNDD);
     if (f_epsilon > tmp1)
       f_epsilon = tmp1;

--- a/fplll/wrapper.cpp
+++ b/fplll/wrapper.cpp
@@ -24,12 +24,13 @@ FPLLL_BEGIN_NAMESPACE
 
 /* prec=53, eta=0.501, dim < dim_double_max [ (delta / 100.0) + 25 ] */
 const double dim_double_max[75] = {
-    0,     26,    29.6,  28.1,  31.1,  32.6,  34.6,  34,    37.7,  38.8,  39.6,  41.8,  40.9,
-    43.6,  44.2,  47,    46.8,  50.6,  49.1,  51.5,  52.5,  54.8,  54.6,  57.4,  57.6,  59.9,
-    61.8,  62.3,  64.5,  67.1,  68.8,  68.3,  69.9,  73.1,  74,    76.1,  76.8,  80.9,  81.8,
-    83,    85.3,  87.9,  89,    90.1,  89,    94.6,  94.8,  98.7,  99,    101.6, 104.9, 106.8,
-    108.2, 107.4, 110,   112.7, 114.6, 118.1, 119.7, 121.8, 122.9, 126.6, 128.6, 129,   133.6,
-    126.9, 135.9, 139.5, 135.2, 137.2, 139.3, 142.8, 142.4, 142.5, 145.4};
+  0,     26,    29.6,  28.1,  31.1,  32.6,  34.6,  34,    37.7,  38.8,  39.6,  41.8,  40.9,
+  43.6,  44.2,  47,    46.8,  50.6,  49.1,  51.5,  52.5,  54.8,  54.6,  57.4,  57.6,  59.9,
+  61.8,  62.3,  64.5,  67.1,  68.8,  68.3,  69.9,  73.1,  74,    76.1,  76.8,  80.9,  81.8,
+  83,    85.3,  87.9,  89,    90.1,  89,    94.6,  94.8,  98.7,  99,    101.6, 104.9, 106.8,
+  108.2, 107.4, 110,   112.7, 114.6, 118.1, 119.7, 121.8, 122.9, 126.6, 128.6, 129,   133.6,
+  126.9, 135.9, 139.5, 135.2, 137.2, 139.3, 142.8, 142.4, 142.5, 145.4
+};
 
 const double eta_dep[10] = {1.,       // 0.5
                             1.,       // 0.55
@@ -40,12 +41,13 @@ const double eta_dep[10] = {1.,       // 0.5
                             1.6231,   // 0.8
                             1.8189,   // 0.85
                             2.1025,   // 0.9
-                            2.5117};  // 0.95
+                            2.5117
+                           };  // 0.95
 
 Wrapper::Wrapper(ZZ_mat<mpz_t> &b, ZZ_mat<mpz_t> &u, ZZ_mat<mpz_t> &u_inv, double delta, double eta,
                  int flags)
-    : status(RED_SUCCESS), b(b), u(u), u_inv(u_inv), delta(delta), eta(eta), use_long(false),
-      last_early_red(0)
+  : status(RED_SUCCESS), b(b), u(u), u_inv(u_inv), delta(delta), eta(eta), use_long(false),
+    last_early_red(0)
 {
   n            = b.get_cols();
   d            = b.get_rows();
@@ -59,8 +61,8 @@ Wrapper::Wrapper(ZZ_mat<mpz_t> &b, ZZ_mat<mpz_t> &u, ZZ_mat<mpz_t> &u_inv, doubl
 // Constructor for HLLL
 Wrapper::Wrapper(ZZ_mat<mpz_t> &b, ZZ_mat<mpz_t> &u, ZZ_mat<mpz_t> &u_inv, double delta, double eta,
                  double theta, double c, int flags)
-    : status(RED_SUCCESS), b(b), u(u), u_inv(u_inv), delta(delta), eta(eta), use_long(false),
-      last_early_red(-1), theta(theta), c(c)
+  : status(RED_SUCCESS), b(b), u(u), u_inv(u_inv), delta(delta), eta(eta), use_long(false),
+    last_early_red(-1), theta(theta), c(c)
 {
   n           = b.get_cols();
   d           = b.get_rows();
@@ -213,7 +215,7 @@ int Wrapper::proved_loop(int precision)
 #ifdef FPLLL_WITH_DPE
     kappa = proved_lll<mpz_t, dpe_t>(b, u, u_inv, 0, delta, eta);
 #else
-    kappa                  = proved_lll<mpz_t, mpfr_t>(b, u, u_inv, precision, delta, eta);
+    kappa = proved_lll<mpz_t, mpfr_t>(b, u, u_inv, precision, delta, eta);
 #endif
   }
 #ifdef FPLLL_WITH_QD
@@ -237,7 +239,7 @@ int Wrapper::proved_loop(int precision)
 int Wrapper::last_lll()
 {
 
-/* <long, FT> */
+  /* <long, FT> */
 #ifdef FPLLL_WITH_ZLONG
   if (use_long)
   {
@@ -254,13 +256,19 @@ int Wrapper::last_lll()
   }
 #endif
 
-/* <mpfr, FT> */
+  /* <mpfr, FT> */
 #ifdef FPLLL_WITH_DPE
   if (good_prec <= numeric_limits<double>::digits)
     return proved_lll<mpz_t, dpe_t>(b, u, u_inv, good_prec, delta, eta);
 #ifdef FPLLL_WITH_QD
   else if (good_prec <= PREC_DD)
-    return proved_lll<mpz_t, dd_real>(b, u, u_inv, good_prec, delta, eta);
+  {
+    max_exponent = b.get_max_exp() + (int)ceil(0.5 * log2((double)d * n));
+    if (max_exponent * 2 < MAX_EXP_DOUBLE)
+    {
+      return proved_lll<mpz_t, dd_real>(b, u, u_inv, good_prec, delta, eta);
+    }
+  }
 #endif
 #endif
   return proved_lll<mpz_t, mpfr_t>(b, u, u_inv, good_prec, delta, eta);
@@ -279,9 +287,9 @@ bool Wrapper::lll()
 
 #ifdef FPLLL_WITH_ZLONG
   bool heuristic_with_long =
-      max_exponent < numeric_limits<long>::digits - 2 && u.empty() && u_inv.empty();
+    max_exponent < numeric_limits<long>::digits - 2 && u.empty() && u_inv.empty();
   bool proved_with_long =
-      2 * max_exponent < numeric_limits<long>::digits - 2 && u.empty() && u_inv.empty();
+    2 * max_exponent < numeric_limits<long>::digits - 2 && u.empty() && u_inv.empty();
 #else
   bool heuristic_with_long = false, proved_with_long = false;
 #endif
@@ -306,7 +314,7 @@ bool Wrapper::lll()
     bool lll_failure = (kappa != 0);
     int last_prec;
 
-/* try fast_lll<mpz_t, long double> */
+    /* try fast_lll<mpz_t, long double> */
 #ifdef FPLLL_WITH_LONG_DOUBLE
     if (lll_failure)
     {
@@ -315,10 +323,10 @@ bool Wrapper::lll()
     }
     last_prec = numeric_limits<long double>::digits;
 #else
-    last_prec   = numeric_limits<double>::digits;
+    last_prec = numeric_limits<double>::digits;
 #endif
 
-/* try fast_lll<mpz_t, dd_real> */
+    /* try fast_lll<mpz_t, dd_real> */
 #ifdef FPLLL_WITH_QD
     if (lll_failure)
     {
@@ -328,7 +336,7 @@ bool Wrapper::lll()
     last_prec = PREC_DD;
 #else
 #ifdef FPLLL_WITH_LONG_DOUBLE
-    last_prec   = numeric_limits<long double>::digits;
+    last_prec = numeric_limits<long double>::digits;
 #else
     last_prec = numeric_limits<double>::digits;
 #endif
@@ -436,7 +444,7 @@ template <class F> bool Wrapper::call_hlll(LLLMethod method, int precision)
  */
 bool Wrapper::last_hlll()
 {
-/* <mpfr, FT> */
+  /* <mpfr, FT> */
 #ifdef FPLLL_WITH_DPE
   if (good_prec <= numeric_limits<double>::digits)
     return proved_hlll<dpe_t>(good_prec);
@@ -482,20 +490,20 @@ bool Wrapper::hlll()
 // fast_hlll<double>()
 // Something like the one used in #if 0 should work
 #if 0
-    /* try fast_lll<mpz_t, double> */
-    int kappa        = fast_lll<double>(delta, eta);
-    bool lll_failure = (kappa != 0);
+  /* try fast_lll<mpz_t, double> */
+  int kappa        = fast_lll<double>(delta, eta);
+  bool lll_failure = (kappa != 0);
 
-    /* try fast_lll<mpz_t, double> */
-    if (lll_failure)
-      hlll_complete = fast_hlll<double>();
-    else
-      hlll_complete = true;
+  /* try fast_lll<mpz_t, double> */
+  if (lll_failure)
+    hlll_complete = fast_hlll<double>();
+  else
+    hlll_complete = true;
 #else   // 0
   hlll_complete = fast_hlll<double>();
 #endif  // 0
 
-/* try fast_hlll<mpz_t, long double> */
+  /* try fast_hlll<mpz_t, long double> */
 #ifdef FPLLL_WITH_LONG_DOUBLE
   if (!hlll_complete)
   {
@@ -504,7 +512,7 @@ bool Wrapper::hlll()
   }
 #endif  // FPLLL_WITH_LONG_DOUBLE
 
-/* try fast_hlll<mpz_t, dd_real> */
+  /* try fast_hlll<mpz_t, dd_real> */
 #ifdef FPLLL_WITH_QD
   if (!hlll_complete)
   {

--- a/tests/test_gso.cpp
+++ b/tests/test_gso.cpp
@@ -248,13 +248,15 @@ template <class ZT, class FT> int test_filename(const char *input_filename)
   }
   if (retvalue & 2)
   {
-    cerr << input_filename << " shows different GSO-outputs for grammatrix representation and "
-                              "basis representation after moving rows.\n";
+    cerr << input_filename
+         << " shows different GSO-outputs for grammatrix representation and "
+            "basis representation after moving rows.\n";
   }
   if (retvalue & 4)
   {
-    cerr << input_filename << " shows different GSO-outputs for grammatrix representation and "
-                              "basis representation after adding rows.\n";
+    cerr << input_filename
+         << " shows different GSO-outputs for grammatrix representation and "
+            "basis representation after adding rows.\n";
   }
   retvalue |= test_householder<ZT, FT>(A);
   if (retvalue > 0)


### PR DESCRIPTION
Related to issue https://github.com/fplll/fplll/issues/362

Other file have been modified since I did make check-style I think. 

The size of the exponent was tested in proved_loop but not in last_lll, the exponent size of 
dd_real is the same the one of double. See the exponent test put now at line 267 of wrapper.cpp

(Besides, a remark : in proved_loop, line 214 could be reached (WITH_QD), with precision 
between numeric_limits<double>::digits  and  PREC_DD, could potentially leadi to a failure since use 
of dpe_t. However, in Wrapper::lll(), the call is heuristic_loop(increase_prec(prec_d)) and 
the increased precision seems to be greater there than PREC_DD.)