### PR TITLE
Support clang-cl on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.la
 *.lo
 *.trs
+*.obj
+*.exe
+*.log
 .deps
 .libs
 Makefile

--- a/fplll/defs.h
+++ b/fplll/defs.h
@@ -23,10 +23,46 @@
 #define FPLLL_WITH_LONG_DOUBLE
 #endif
 
+#ifdef _MSC_VER
+// For M_LN2
+#define _USE_MATH_DEFINES
+// To avoid min max macros
+#define NOMINMAX
+
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#include <winsock2.h>
+#include <stdint.h>
+
+// Taken from https://stackoverflow.com/a/26085827
+static inline int gettimeofday(struct timeval * tp, struct timezone * tzp)
+{
+    // Note: some broken versions only have 8 trailing zero's, the correct epoch has 9 trailing zero's
+    // This magic number is the number of 100 nanosecond intervals since January 1, 1601 (UTC)
+    // until 00:00:00 January 1, 1970
+    static const uint64_t EPOCH = ((uint64_t) 116444736000000000ULL);
+
+    SYSTEMTIME  system_time;
+    FILETIME    file_time;
+    uint64_t    time;
+
+    GetSystemTime( &system_time );
+    SystemTimeToFileTime( &system_time, &file_time );
+    time =  ((uint64_t)file_time.dwLowDateTime )      ;
+    time += ((uint64_t)file_time.dwHighDateTime) << 32;
+
+    tp->tv_sec  = (long) ((time - EPOCH) / 10000000L);
+    tp->tv_usec = (long) (system_time.wMilliseconds * 1000);
+    return 0;
+}
+#endif
+
 #define FPLLL_WITH_DPE
 #define FPLLL_WITH_ZDOUBLE
 #define FPLLL_WITH_ZLONG
+#ifndef _MSC_VER
 #define FPLLL_WITH_GETRUSAGE
+#endif
 
 #include <algorithm>
 #include <climits>


### PR DESCRIPTION
clang-cl is MSVC ABI compatible and autoconf can use clang-cl
with cccl wrapper.

Things to do in the future.
- support building dlls. (Need to add `__declspec(dllexport)` macros to public functions and data)
- getopt alternative for sieve_main