### PR TITLE
Optional latsieve isn't a thing anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ equal iff d=d' and for any i, bi = +- ci. Concretely, if basis B is in file 'B.t
 ## latsieve ##
 
 `latsieve` does (tuple) lattice sieve on a matrix (considered as a set of row
-vectors) given in a file as parameter. You may compile it by using `make latsieve`.
+vectors) given in a file as parameter. 
  It will generate the executable file
  `latsieve` in `fplll/` which is a wrapper of `fplll/.libs/latsieve`.
 

--- a/fplll/nr/numvect.h
+++ b/fplll/nr/numvect.h
@@ -134,6 +134,8 @@ public:
   NumVect() {}
   /** Initializes NumVect with the elements of the given NumVect. */
   NumVect(const NumVect &v) : data(v.data) {}
+  /** Initializes NumVect with the elements of a given vector. */
+  NumVect(const vector<T> &v) : data(v) {}
   /** Initializes NumVect of specific size, The initial content is
       undefined. */
   NumVect(int size) : data(size) {}
@@ -164,6 +166,12 @@ public:
     data.resize(size);
     fill(0);
   }
+
+  /**Compares two NumVects by comparing the underlying vectors. Returns true if equivalent & false
+   * otherwise.
+   * Note that this only works if the two NumVects have the same template type parameter. **/
+  bool operator==(NumVect<T> &other) { return other.data == data; }
+
   /** Inserts an element in the back of NumVect. */
   void push_back(const T &t) { data.push_back(t); }
   /** Removes the back element of NumVect. */


### PR DESCRIPTION
When running the "make latsieve command" I get a "no rule" error - it appears that this isn't a valid target anymore, and that we always build the sieve directory & related classes under the regular make command.
 
As a result, I've removed the "make latsieve" sentence.

This might be irrelevant though if issue #369 is finalised before the next release.
