### PR TITLE
Fix out-of-bounds vector accesses in Pruner::enforce.

### DIFF
--- a/fplll/pruner/pruner.h
+++ b/fplll/pruner/pruner.h
@@ -1027,8 +1027,8 @@ template <class FT> inline bool Pruner<FT>::enforce(/*io*/ vec &b, /*opt i*/ con
     status |= (b[i] > 1.0001);
     b[i] = b[i] > 1 ? 1. : b[i];
 
-    // note min_pruning_coefficients always has length n
-    if (b[i] <= min_pruning_coefficients[i / c])
+    // note min_pruning_coefficients always has length d
+    if (i / c < d && b[i] <= min_pruning_coefficients[i / c])
       b[i] = min_pruning_coefficients[i / c];
   }
 
@@ -1041,7 +1041,7 @@ template <class FT> inline bool Pruner<FT>::enforce(/*io*/ vec &b, /*opt i*/ con
     }
   }
 
-  for (int i = j - 1; i >= 0; --i)
+  for (int i = std::min(j - 1, dn - 2); i >= 0; --i)
   {
     if (b[i + 1] < b[i])
     {


### PR DESCRIPTION
I have been testing builds for fplll 5.3.0 and fpylll 0.5.0dev for Fedora.  The default Fedora build flags include -D_GLIBCXX_ASSERTIONS.  This led to test failures in fpylll due to out of bounds vector accesses in the fplll code.  This commit fixes the two such out of bounds accesses found by the fpylll tests.  (I highly recommend that you build with -D_GLIBCXX_ASSERTIONS before running your tests, by the way.)

In the first hunk, note that min_pruning_coefficients always has length *d*, not n.  The fpylll test suite, at least, invokes this code in such a way that i / c can be equal to d and therefore one past the end of the min_pruning_coefficients vector.

In the second hunk, j can be as large as as dn (b.size()), and therefore on the first iteration of the loop, when i is j - 1, then b[i + 1] == b[j] is one past the end of b.