### PR TITLE
Fix the libraries listed in the pkg-config file

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,6 @@ AS_IF([test "x$enable_mpir" = "xyes"], [
 	   ])
 	AC_CHECK_LIB(mpir, __gmp_get_memory_functions, , [AC_MSG_ERROR(
 	[MPIR version >= 1.0.0 needed, see http://mpir.org])])
-        LIBGMP="-lmpir"
 ])
 
 AS_IF([test "x$enable_mpir" != "xyes"], [
@@ -81,10 +80,7 @@ AS_IF([test "x$enable_mpir" != "xyes"], [
 	   ])
 	AC_CHECK_LIB(gmp, __gmp_get_memory_functions, , [AC_MSG_ERROR(
 	[GMP version >= 4.2.0 needed, see http://gmplib.org])])
-        LIBGMP="-lgmp"
 ])
-
-AC_SUBST(LIBGMP)
 
 AC_ARG_WITH(mpfr,
    AS_HELP_STRING([--with-mpfr=@<:@=DIR@:>@], [MPFR install directory]), [

--- a/configure.ac
+++ b/configure.ac
@@ -67,10 +67,8 @@ AS_IF([test "x$enable_mpir" = "xyes"], [
 	      LDFLAGS="$LDFLAGS -L$withval/lib"
 	      mpir_lib_path="$withval/lib"
 	   ])
-	AC_CHECK_LIB(mpir, __gmpz_init, , [AC_MSG_ERROR(
-	[MPIR not found, see http://mpir.org])])
 	AC_CHECK_LIB(mpir, __gmp_get_memory_functions, , [AC_MSG_ERROR(
-	[MPIR version too old, need >= 1.0.0, see http://mpir.org])])
+	[MPIR version >= 1.0.0 needed, see http://mpir.org])])
         LIBGMP="-lmpir"
 ])
 
@@ -81,10 +79,8 @@ AS_IF([test "x$enable_mpir" != "xyes"], [
 	      LDFLAGS="$LDFLAGS -L$withval/lib"
 	      mpir_lib_path="$withval/lib"
 	   ])
-	AC_CHECK_LIB(gmp, __gmpz_init, , [AC_MSG_ERROR(
-	[GNU MP not found, see http://mpir.org])])
 	AC_CHECK_LIB(gmp, __gmp_get_memory_functions, , [AC_MSG_ERROR(
-	[GMP version too old, need >= 4.2.0, see http://gmplib.org])])
+	[GMP version >= 4.2.0 needed, see http://gmplib.org])])
         LIBGMP="-lgmp"
 ])
 
@@ -97,11 +93,8 @@ AC_ARG_WITH(mpfr,
        mpfr_lib_path="$withval/lib"
    ])
 
-AC_CHECK_LIB(mpfr, mpfr_add, , [AC_MSG_ERROR(
-[MPFR not found, see http://www.mpfr.org])])
-
 AC_CHECK_LIB(mpfr, mpfr_fms, , [AC_MSG_ERROR(
-[MPFR version too old, need >= 2.3.0, see http://www.mpfr.org])])
+[MPFR version >= 2.3.0 needed, see http://www.mpfr.org])])
 
 AC_ARG_WITH(qd, AS_HELP_STRING([--with-qd=@<:@=DIR@:>@], [quaddouble install directory]),)
 

--- a/configure.ac
+++ b/configure.ac
@@ -129,6 +129,11 @@ AS_IF([test "x${have_libqd}" = "xyes"], [
   AC_DEFINE([FPLLL_WITH_QD], [1], [defined when libqd is usable])
 ])
 
+# This will be non-empty if we found qd using pkg-config, or if a path
+# was passed to --with-qd=<path> and we set the variable ourselves. If
+# we found libqd via a manual library search, on the other hand, then
+# the linker flag will be found in LIBS instead because that's just how
+# the AC_SEARCH_LIBS macro works.
 AC_SUBST(LIBQD_LIBS)
 
 # Checks for header files.

--- a/fplll.pc.in
+++ b/fplll.pc.in
@@ -7,4 +7,4 @@ Name: @PACKAGE_NAME@
 Description: lattice algorithms with floating-point computations
 Version: @PACKAGE_VERSION@
 Cflags: @PTHREAD_CFLAGS@
-Libs: -L${libdir} @LIBQD_LIBS@ @LIBGMP@ @PTHREAD_LIBS@ -lmpfr -lfplll
+Libs: -L${libdir} @LIBQD_LIBS@ @PTHREAD_LIBS@ @LIBS@ -lfplll

--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -107,7 +107,7 @@ libfplll_la_SOURCES=fplll.cpp fplll.h \
 libfplll_la_CXXFLAGS=$(PTHREAD_CFLAGS)
 
 EXTRA_libfplll_la_SOURCES= svpcvp.cpp
-libfplll_la_LIBADD=$(LIBS) $(LIBQD_LIBS) $(PTHREAD_LIBS)
+libfplll_la_LIBADD=$(LIBQD_LIBS) $(PTHREAD_LIBS)
 libfplll_la_LDFLAGS=-no-undefined -version-info @FPLLL_LT_CURRENT@:@FPLLL_LT_REVISION@:@FPLLL_LT_AGE@ $(PTHREAD_CFLAGS)
 
 if FPLLL_PARALLEL_ENUM

--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -107,7 +107,7 @@ libfplll_la_SOURCES=fplll.cpp fplll.h \
 libfplll_la_CXXFLAGS=$(PTHREAD_CFLAGS)
 
 EXTRA_libfplll_la_SOURCES= svpcvp.cpp
-libfplll_la_LIBADD=$(LIBGMP) -lmpfr $(LIBQD_LIBS) $(PTHREAD_LIBS)
+libfplll_la_LIBADD=$(LIBS) $(LIBQD_LIBS) $(PTHREAD_LIBS)
 libfplll_la_LDFLAGS=-no-undefined -version-info @FPLLL_LT_CURRENT@:@FPLLL_LT_REVISION@:@FPLLL_LT_AGE@ $(PTHREAD_CFLAGS)
 
 if FPLLL_PARALLEL_ENUM

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -44,8 +44,8 @@ AM_LDFLAGS = -L$(STAGEDIR) -Wl,-rpath,$(STAGEDIR) -lfplll -no-install $(LIBQD_LI
 
 TESTS = test_nr test_lll test_enum test_cvp test_svp test_bkz test_pruner test_sieve test_gso test_lll_gram test_hlll test_svp_gram test_bkz_gram
 
-test_pruner_LDADD=$(LIBGMP) -lmpfr $(LIBQD_LIBS)
-test_sieve_LDADD=$(LIBGMP) -lmpfr $(LIBQD_LIBS)
+test_pruner_LDADD=$(LIBS) $(LIBQD_LIBS)
+test_sieve_LDADD=$(LIBS) $(LIBQD_LIBS)
 
 test_nr_SOURCES = test_nr.cpp
 test_lll_SOURCES = test_lll.cpp

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -44,8 +44,8 @@ AM_LDFLAGS = -L$(STAGEDIR) -Wl,-rpath,$(STAGEDIR) -lfplll -no-install $(LIBQD_LI
 
 TESTS = test_nr test_lll test_enum test_cvp test_svp test_bkz test_pruner test_sieve test_gso test_lll_gram test_hlll test_svp_gram test_bkz_gram
 
-test_pruner_LDADD=$(LIBS) $(LIBQD_LIBS)
-test_sieve_LDADD=$(LIBS) $(LIBQD_LIBS)
+test_pruner_LDADD=$(LIBQD_LIBS)
+test_sieve_LDADD=$(LIBQD_LIBS)
 
 test_nr_SOURCES = test_nr.cpp
 test_lll_SOURCES = test_lll.cpp


### PR DESCRIPTION
When no pkg-config file is present and when qd was automatically detected, the `-lqd` flag was winding up in `LIBS` rather than `LIBQD_LIBS`. The other linker flags that arise from the `AC_CHECK_LIB` macro also wind up in `LIBS`, so it makes sense to put `LIBS` in the pkg-config file, replacing some of the existing "custom" entries. The remaining commits attempt to eliminate the duplicate flags. Hopefully the individual commit messages explain.