### PR TITLE
Added constructors from  #417

### DIFF
--- a/fplll/nr/nr_Z.inl
+++ b/fplll/nr/nr_Z.inl
@@ -26,6 +26,7 @@ public:
    */
   inline Z_NR<Z>();
   inline Z_NR<Z>(const Z_NR<Z> &z);
+  inline Z_NR<Z>(const Z &z);
   inline ~Z_NR<Z>();
 
   /** get data */
@@ -125,7 +126,7 @@ public:
   inline bool operator==(long a) const;
   inline bool operator!=(const Z_NR<Z> &a) const;
   inline bool operator!=(long a) const;
-
+  
   /**
    * max between a and b
    */

--- a/fplll/nr/nr_Z.inl
+++ b/fplll/nr/nr_Z.inl
@@ -126,7 +126,7 @@ public:
   inline bool operator==(long a) const;
   inline bool operator!=(const Z_NR<Z> &a) const;
   inline bool operator!=(long a) const;
-  
+
   /**
    * max between a and b
    */

--- a/fplll/nr/nr_Z_d.inl
+++ b/fplll/nr/nr_Z_d.inl
@@ -124,7 +124,6 @@ template <> inline bool Z_NR<double>::operator!=(long a) const
   return data != static_cast<double>(a);
 }
 
-
 /** arithmetic */
 template <> inline void Z_NR<double>::add(const Z_NR<double> &a, const Z_NR<double> &b)
 {

--- a/fplll/nr/nr_Z_d.inl
+++ b/fplll/nr/nr_Z_d.inl
@@ -13,7 +13,7 @@ FPLLL_BEGIN_NAMESPACE
 template <> inline Z_NR<double>::Z_NR() {}
 
 template <> inline Z_NR<double>::Z_NR(const Z_NR<double> &z) : data(z.data) {}
-
+template <> inline Z_NR<double>::Z_NR(const double &z) : data(z) {}
 template <> inline Z_NR<double>::~Z_NR() {}
 
 /** get data */
@@ -123,6 +123,7 @@ template <> inline bool Z_NR<double>::operator!=(long a) const
 {
   return data != static_cast<double>(a);
 }
+
 
 /** arithmetic */
 template <> inline void Z_NR<double>::add(const Z_NR<double> &a, const Z_NR<double> &b)

--- a/fplll/nr/nr_Z_l.inl
+++ b/fplll/nr/nr_Z_l.inl
@@ -13,7 +13,7 @@ FPLLL_BEGIN_NAMESPACE
 template <> inline Z_NR<long>::Z_NR() {}
 
 template <> inline Z_NR<long>::Z_NR(const Z_NR<long> &z) : data(z.data) {}
-
+template <> inline Z_NR<long>::Z_NR(const long &z) : data(z) {}
 template <> inline Z_NR<long>::~Z_NR() {}
 
 /** get data */
@@ -99,7 +99,6 @@ template <> inline bool Z_NR<long>::operator==(long a) const { return data == a;
 template <> inline bool Z_NR<long>::operator!=(const Z_NR<long> &a) const { return data != a.data; }
 
 template <> inline bool Z_NR<long>::operator!=(long a) const { return data != a; }
-
 /** arithmetic */
 template <> inline void Z_NR<long>::add(const Z_NR<long> &a, const Z_NR<long> &b)
 {

--- a/fplll/nr/nr_Z_mpz.inl
+++ b/fplll/nr/nr_Z_mpz.inl
@@ -11,7 +11,7 @@ FPLLL_BEGIN_NAMESPACE
 template <> inline Z_NR<mpz_t>::Z_NR() { mpz_init(data); }
 
 template <> inline Z_NR<mpz_t>::Z_NR(const Z_NR<mpz_t> &z) { mpz_init_set(data, z.data); }
-
+template <> inline Z_NR<mpz_t>::Z_NR(const mpz_t &z) {mpz_init_set(data,z);}
 template <> inline Z_NR<mpz_t>::~Z_NR() { mpz_clear(data); }
 
 /** get data */

--- a/fplll/nr/nr_Z_mpz.inl
+++ b/fplll/nr/nr_Z_mpz.inl
@@ -11,6 +11,8 @@ FPLLL_BEGIN_NAMESPACE
 template <> inline Z_NR<mpz_t>::Z_NR() { mpz_init(data); }
 
 template <> inline Z_NR<mpz_t>::Z_NR(const Z_NR<mpz_t> &z) { mpz_init_set(data, z.data); }
+
+// Note - you'll still need to call mpz_free on a, because references are non-owning.
 template <> inline Z_NR<mpz_t>::Z_NR(const mpz_t &z) { mpz_init_set(data, z); }
 template <> inline Z_NR<mpz_t>::~Z_NR() { mpz_clear(data); }
 

--- a/fplll/nr/nr_Z_mpz.inl
+++ b/fplll/nr/nr_Z_mpz.inl
@@ -11,7 +11,7 @@ FPLLL_BEGIN_NAMESPACE
 template <> inline Z_NR<mpz_t>::Z_NR() { mpz_init(data); }
 
 template <> inline Z_NR<mpz_t>::Z_NR(const Z_NR<mpz_t> &z) { mpz_init_set(data, z.data); }
-template <> inline Z_NR<mpz_t>::Z_NR(const mpz_t &z) {mpz_init_set(data,z);}
+template <> inline Z_NR<mpz_t>::Z_NR(const mpz_t &z) { mpz_init_set(data, z); }
 template <> inline Z_NR<mpz_t>::~Z_NR() { mpz_clear(data); }
 
 /** get data */

--- a/fplll/nr/nr_Z_mpz.inl
+++ b/fplll/nr/nr_Z_mpz.inl
@@ -54,6 +54,7 @@ template <> inline int Z_NR<mpz_t>::sgn() const { return mpz_sgn(data); }
 /** operator */
 template <> inline void Z_NR<mpz_t>::operator=(const Z_NR<mpz_t> &a) { mpz_set(data, a.data); }
 
+// Note - you'll still need to call mpz_free on a, because references are non-owning.
 template <> inline void Z_NR<mpz_t>::operator=(const mpz_t &a) { mpz_set(data, a); }
 
 template <> inline void Z_NR<mpz_t>::operator=(long a) { mpz_set_si(data, a); }


### PR DESCRIPTION
 #417 asks for copy-assignment/move-assignment constructors for the integer types.
Thankfully, C++ compilers mostly implement this for us; the only important bit is adding in the copy constructors (I didn't add in move-assignment because I don't think it's used anywhere else in fplll...).

This PR implements #417 . It's now possible to write:

``` 
mpz_t temp;
mpz_init(temp, 5);
Z_NR<mpz_t> out(temp)
```
and:

``` Z_NR<mpz_t> out = Z_NR<mpz_t>(temp); ```

as requested. 

It also does it for all of the integral types - so mpz_t above could be replaced by ```long``` or ```double``` and it would still work.

Note; I didn't implement the request for a % operator.