### PR TITLE
Added modulus operation 

### DIFF
--- a/fplll/nr/nr_Z.inl
+++ b/fplll/nr/nr_Z.inl
@@ -157,6 +157,11 @@ public:
   inline void sub_ui(const Z_NR<Z> &a, unsigned int b);
 
   /**
+   * value := a mod b
+   */
+  inline void mod(const Z_NR<Z> &a, const Z_NR<Z> &b);
+
+  /**
    * value := -a.
    */
   inline void neg(const Z_NR<Z> &a);

--- a/fplll/nr/nr_Z_d.inl
+++ b/fplll/nr/nr_Z_d.inl
@@ -145,6 +145,11 @@ template <> inline void Z_NR<double>::sub_ui(const Z_NR<double> &a, unsigned int
   data = a.data - static_cast<double>(b);
 }
 
+template <> inline void Z_NR<double>::mod(const Z_NR<double> &a, const Z_NR<double> &b)
+{
+  data = std::fmod(a.data, b.data);
+}
+
 template <> inline void Z_NR<double>::neg(const Z_NR<double> &a) { data = -a.data; }
 
 template <> inline void Z_NR<double>::mul(const Z_NR<double> &a, const Z_NR<double> &b)

--- a/fplll/nr/nr_Z_l.inl
+++ b/fplll/nr/nr_Z_l.inl
@@ -119,7 +119,10 @@ template <> inline void Z_NR<long>::sub_ui(const Z_NR<long> &a, unsigned int b)
 {
   data = a.data - b;
 }
-
+template <> inline void Z_NR<long>::mod(const Z_NR<long> &a, const Z_NR<long> &b)
+{
+  data = a.data % b.data;
+}
 template <> inline void Z_NR<long>::neg(const Z_NR<long> &a) { data = -a.data; }
 
 template <> inline void Z_NR<long>::mul(const Z_NR<long> &a, const Z_NR<long> &b)

--- a/fplll/nr/nr_Z_mpz.inl
+++ b/fplll/nr/nr_Z_mpz.inl
@@ -124,6 +124,11 @@ template <> inline void Z_NR<mpz_t>::sub_ui(const Z_NR<mpz_t> &a, unsigned int b
   mpz_sub_ui(data, a.data, b);
 }
 
+template <> inline void Z_NR<mpz_t>::mod(const Z_NR<mpz_t> &a, const Z_NR<mpz_t> &b)
+{
+  mpz_mod(data, a.data, b.data);
+}
+
 template <> inline void Z_NR<mpz_t>::neg(const Z_NR<mpz_t> &a) { mpz_neg(data, a.data); }
 
 template <> inline void Z_NR<mpz_t>::mul(const Z_NR<mpz_t> &a, const Z_NR<mpz_t> &b)


### PR DESCRIPTION
This is the second part from #417 - Z_NR now has a modulus operation. 

The implementation merely adds wrappers for Z_NR; internally, each method delegates to the modulus operations for the underlying types.

Usage is very similar to all of the other operations (add, mul etc). 
For example: 
```
Z_NR<mpz_t> out = 0;
Z_NR<mpz_t> radix = 5;
Z_NR<mpz_t> modulus = 3;
out.mod(radix, modulus);
```
Note that the template type parameters must be the same; I think mixing the types is a bad idea. 