### PR TITLE
Add verbose guard to cputime in hlll, lll and bkz

### DIFF
--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -559,7 +559,8 @@ template <class ZT, class FT> bool BKZReduction<ZT, FT>::bkz()
     print_params(param, cerr);
     cerr << endl;
   }
-  cputime_start = cputime();
+  
+  cputime_start = (flags & BKZ_DUMP_GSO) ? cputime() : 0;
 
   m.discover_all_rows();
 

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -559,8 +559,8 @@ template <class ZT, class FT> bool BKZReduction<ZT, FT>::bkz()
     print_params(param, cerr);
     cerr << endl;
   }
-  
-  cputime_start = (flags & BKZ_DUMP_GSO) ? cputime() : 0;
+
+  cputime_start = ((flags & BKZ_DUMP_GSO) || (flags & BKZ_MAX_TIME)) ? cputime() : 0;
 
   m.discover_all_rows();
 

--- a/fplll/hlll.cpp
+++ b/fplll/hlll.cpp
@@ -33,7 +33,7 @@ template <class ZT, class FT> bool HLLLReduction<ZT, FT>::hlll()
    * Experimentally, the delta used during the computation must be equal to
    * (delta + (0.01 or 0.02) to have an basis which is HLLL-reduced w.r.t delta.
    */
-  int start_time = cputime();
+  int start_time = (verbose) ? cputime() : 0;
   // True if the corresponding vector is weak size-reduced
   bool status_sr = true;
 

--- a/fplll/lll.cpp
+++ b/fplll/lll.cpp
@@ -49,7 +49,7 @@ bool LLLReduction<ZT, FT>::lll(int kappa_min, int kappa_start, int kappa_end,
     kappa_end = m.d;
 
   FPLLL_DEBUG_CHECK(kappa_min <= kappa_start && kappa_start < kappa_end && kappa_end <= m.d);
-  int start_time = cputime();
+  int start_time = (verbose) ? cputime() : 0;
   int kappa      = kappa_start + 1;
   int kappa_max  = 0;
   int d          = kappa_end - kappa_min;


### PR DESCRIPTION
This pull request addresses #435 .

## What changes?
* Add ```verbose``` guard to calls to ```cputime``` in ```hlll.cpp```, ```lll.cpp``` and ```bkz.cpp```. Some of the calls mentioned in #435 are already wrapped inside an ```if``` statement that checks ```verbose```, so it doesn't make sense to double wrap these.

## What doesn't it change?
There's no new flag. In particular, in ```bkz.cpp``` every call relies exclusively on ```BKZ_DUMP_GSO```.

The reason why is because every  ```cputime```  call (other than the one changed in this PR) is already inside a check on ```BKZ_DUMP_GSO```; I don't think it makes sense to remove the call to ```cputime``` there, because it's probably a sensible default for ```BKZ_DUMP_GSO```. This is compounded by the fact that the call to ```print_tour``` is inside a check on ```BKZ_DUMP_GSO```; so this seems like expected behaviour. 

If it's necessary, I'm happy to add another parameter (something like ```BKZ_DUMP_GSO_NO_TIME```), or to change the default behaviour of ```BKZ_DUMP_GSO``` but this is something I wanted to check first (as it's a change in the current behaviour).