### PR TITLE
Count nodes by level, rather than by tree

### DIFF
--- a/fplll/enum-parallel/enumlib.cpp
+++ b/fplll/enum-parallel/enumlib.cpp
@@ -34,16 +34,17 @@ namespace enumlib
 
 using namespace std;
 
-uint64_t enumlib_enumerate(int dim, fplll::enumf maxdist,
-                           std::function<fplll::extenum_cb_set_config> cbfunc,
-                           std::function<fplll::extenum_cb_process_sol> cbsol,
-                           std::function<fplll::extenum_cb_process_subsol> cbsubsol, bool dual,
-                           bool findsubsols);
+array<uint64_t, FPLLL_MAX_ENUM_DIM>
+enumlib_enumerate(int dim, fplll::enumf maxdist, std::function<fplll::extenum_cb_set_config> cbfunc,
+                  std::function<fplll::extenum_cb_process_sol> cbsol,
+                  std::function<fplll::extenum_cb_process_subsol> cbsubsol, bool dual,
+                  bool findsubsols);
 
 #define ENUMFUNCNAME(DIM)                                                                          \
-  uint64_t enumerate##DIM(int, float_type, std::function<extenum_cb_set_config>,                   \
-                          std::function<extenum_cb_process_sol>,                                   \
-                          std::function<extenum_cb_process_subsol>, bool, bool);
+  array<uint64_t, FPLLL_MAX_ENUM_DIM> enumerate##DIM(                                              \
+      int, float_type, std::function<extenum_cb_set_config>,                                       \
+      std::function<extenum_cb_process_sol>, std::function<extenum_cb_process_subsol>, bool,       \
+      bool);
 
 #if 20 <= FPLLL_MAX_PARALLEL_ENUM_DIM
 ENUMFUNCNAME(20);
@@ -91,15 +92,18 @@ ENUMFUNCNAME(150);
 ENUMFUNCNAME(160);
 #endif
 
-uint64_t enumlib_enumerate(int dim, fplll_float maxdist,
-                           std::function<extenum_cb_set_config> cbfunc,
-                           std::function<extenum_cb_process_sol> cbsol,
-                           std::function<extenum_cb_process_subsol> cbsubsol, bool dual,
-                           bool findsubsols)
+array<uint64_t, FPLLL_MAX_ENUM_DIM>
+enumlib_enumerate(int dim, fplll_float maxdist, std::function<extenum_cb_set_config> cbfunc,
+                  std::function<extenum_cb_process_sol> cbsol,
+                  std::function<extenum_cb_process_subsol> cbsubsol, bool dual, bool findsubsols)
 {
   // dual svp enumeration not supported yet
   if (dim <= 10 || dual)
-    return ~uint64_t(0);
+  {
+    array<uint64_t, FPLLL_MAX_ENUM_DIM> out;
+    out[0] = ~uint64_t(0);
+    return out;
+  }
 
 #if 20 <= FPLLL_MAX_PARALLEL_ENUM_DIM
   if (dim <= 20)
@@ -161,7 +165,9 @@ uint64_t enumlib_enumerate(int dim, fplll_float maxdist,
   if (dim <= 160)
     return enumerate160(dim, maxdist, cbfunc, cbsol, cbsubsol, dual, findsubsols);
 #endif
-  return ~uint64_t(0);
+  array<uint64_t, FPLLL_MAX_ENUM_DIM> out;
+  out[0] = ~uint64_t(0);
+  return out;
 }
 
 }  // namespace enumlib

--- a/fplll/enum-parallel/enumlib.h
+++ b/fplll/enum-parallel/enumlib.h
@@ -33,11 +33,10 @@ FPLLL_BEGIN_NAMESPACE
 namespace enumlib
 {
 
-uint64_t enumlib_enumerate(int dim, ::fplll::enumf maxdist,
-                           std::function<::fplll::extenum_cb_set_config> cbfunc,
-                           std::function<::fplll::extenum_cb_process_sol> cbsol,
-                           std::function<::fplll::extenum_cb_process_subsol> cbsubsol, bool dual,
-                           bool findsubsols);
+array<uint64_t, FPLLL_MAX_ENUM_DIM> enumlib_enumerate(
+    int dim, ::fplll::enumf maxdist, std::function<::fplll::extenum_cb_set_config> cbfunc,
+    std::function<::fplll::extenum_cb_process_sol> cbsol,
+    std::function<::fplll::extenum_cb_process_subsol> cbsubsol, bool dual, bool findsubsols);
 
 }  // namespace enumlib
 

--- a/fplll/enum-parallel/enumlib_dim.cpp
+++ b/fplll/enum-parallel/enumlib_dim.cpp
@@ -43,10 +43,11 @@ template <int dimension> struct enumerate_traits
 };
 
 template <int dimension, bool findsubsols>
-uint64_t enumerate_dim_detail(int dim, float_type maxdist,
-                              std::function<extenum_cb_set_config> cb_set_config,
-                              std::function<extenum_cb_process_sol> cb_process_sol,
-                              std::function<extenum_cb_process_subsol> cb_process_subsol, bool dual)
+array<uint64_t, FPLLL_MAX_ENUM_DIM>
+enumerate_dim_detail(int dim, float_type maxdist,
+                     std::function<extenum_cb_set_config> cb_set_config,
+                     std::function<extenum_cb_process_sol> cb_process_sol,
+                     std::function<extenum_cb_process_subsol> cb_process_subsol, bool dual)
 {
   static const int SWIRLY          = enumerate_traits<dimension>::SWIRLY;
   static const int SWIRLY2BUF      = enumerate_traits<dimension>::SWIRLY2BUF;
@@ -77,18 +78,20 @@ uint64_t enumerate_dim_detail(int dim, float_type maxdist,
       }
     }
   }
-  uint64_t count = 0;
-  for (int j = 0; j <= dimension; ++j)
-    count += lat._counts[j];
-  return count;
+  static_assert(FPLLL_MAX_ENUM_DIM > dimension,
+                "The maximum enumeration dimension needs to be bigger than, or equal to, the "
+                "parallel enumeration dim");
+  array<uint64_t, FPLLL_MAX_ENUM_DIM> arr;
+  std::copy(lat._counts.cbegin(), lat._counts.cend(), arr.begin());
+  return arr;
 }
 
 template <int dimension>
-uint64_t enumerate_dim(int dim, float_type maxdist,
-                       std::function<extenum_cb_set_config> cb_set_config,
-                       std::function<extenum_cb_process_sol> cb_process_sol,
-                       std::function<extenum_cb_process_subsol> cb_process_subsol, bool dual,
-                       bool findsubsols)
+array<uint64_t, FPLLL_MAX_ENUM_DIM>
+enumerate_dim(int dim, float_type maxdist, std::function<extenum_cb_set_config> cb_set_config,
+              std::function<extenum_cb_process_sol> cb_process_sol,
+              std::function<extenum_cb_process_subsol> cb_process_subsol, bool dual,
+              bool findsubsols)
 {
   if (findsubsols)
     return enumerate_dim_detail<dimension, true>(dim, maxdist, cb_set_config, cb_process_sol,
@@ -109,11 +112,10 @@ uint64_t enumerate_dim(int dim, float_type maxdist,
                               dual, findsubsols);                                                  \
     break;
 
-uint64_t DIMFUNC(ENUMDIMENSION)(int dim, float_type maxdist,
-                                std::function<extenum_cb_set_config> cb_set_config,
-                                std::function<extenum_cb_process_sol> cb_process_sol,
-                                std::function<extenum_cb_process_subsol> cb_process_subsol,
-                                bool dual, bool findsubsols)
+array<uint64_t, FPLLL_MAX_ENUM_DIM> DIMFUNC(ENUMDIMENSION)(
+    int dim, float_type maxdist, std::function<extenum_cb_set_config> cb_set_config,
+    std::function<extenum_cb_process_sol> cb_process_sol,
+    std::function<extenum_cb_process_subsol> cb_process_subsol, bool dual, bool findsubsols)
 {
   static const int d = ENUMDIMENSION;
   switch (dim)
@@ -131,7 +133,9 @@ uint64_t DIMFUNC(ENUMDIMENSION)(int dim, float_type maxdist,
   }
 
   cout << "[enumlib] " << ENUMDIMENSION << ":" << dim << " wrong dimension!" << endl;
-  return ~uint64_t(0);
+  array<uint64_t, FPLLL_MAX_ENUM_DIM> arr;
+  arr[0] = ~uint64_t(0);
+  return arr;
 }
 
 }  // namespace enumlib

--- a/fplll/enum-parallel/enumlib_dim.cpp
+++ b/fplll/enum-parallel/enumlib_dim.cpp
@@ -81,7 +81,7 @@ enumerate_dim_detail(int dim, float_type maxdist,
   static_assert(FPLLL_MAX_ENUM_DIM > dimension,
                 "The maximum enumeration dimension needs to be bigger than, or equal to, the "
                 "parallel enumeration dim");
-  array<uint64_t, FPLLL_MAX_ENUM_DIM> arr;
+  array<uint64_t, FPLLL_MAX_ENUM_DIM> arr{};
   std::copy(lat._counts.cbegin(), lat._counts.cend(), arr.begin());
   return arr;
 }
@@ -133,7 +133,7 @@ array<uint64_t, FPLLL_MAX_ENUM_DIM> DIMFUNC(ENUMDIMENSION)(
   }
 
   cout << "[enumlib] " << ENUMDIMENSION << ":" << dim << " wrong dimension!" << endl;
-  array<uint64_t, FPLLL_MAX_ENUM_DIM> arr;
+  array<uint64_t, FPLLL_MAX_ENUM_DIM> arr{};
   arr[0] = ~uint64_t(0);
   return arr;
 }

--- a/fplll/enum/enumerate.cpp
+++ b/fplll/enum/enumerate.cpp
@@ -230,7 +230,7 @@ template <typename ZT, typename FT> void EnumerationDyn<ZT, FT>::set_bounds()
 
 template <typename ZT, typename FT> void EnumerationDyn<ZT, FT>::process_solution(enumf newmaxdist)
 {
-  FPLLL_TRACE("Sol dist: " << newmaxdist << " (nodes:" << nodes << ")");
+  FPLLL_TRACE("Sol dist: " << newmaxdist << " (nodes:" << get_nodes() << ")");
   for (int j = 0; j < d; ++j)
     fx[j] = x[j];
   _evaluator.eval_sol(fx, newmaxdist, maxdist);
@@ -250,7 +250,7 @@ void EnumerationDyn<ZT, FT>::process_subsolution(int offset, enumf newdist)
 
 template <typename ZT, typename FT> void EnumerationDyn<ZT, FT>::do_enumerate()
 {
-  nodes = 0;
+  std::fill(nodes.begin(), nodes.end(), 0);
 
   set_bounds();
 

--- a/fplll/enum/enumerate.h
+++ b/fplll/enum/enumerate.h
@@ -117,6 +117,8 @@ public:
     return _nodes[level];
   }
 
+  inline array<uint64_t, EnumerationBase::maxdim> get_nodes_array() const { return _nodes; }
+
 private:
   MatGSOInterface<ZT, FT> &_gso;
   Evaluator<FT> &_evaluator;

--- a/fplll/enum/enumerate.h
+++ b/fplll/enum/enumerate.h
@@ -36,6 +36,7 @@ public:
       : _gso(gso), _evaluator(evaluator)
   {
     _max_indices = max_indices;
+    std::fill(nodes.begin(), nodes.end(), 0);
   }
 
   void enumerate(int first, int last, FT &fmaxdist, long fmaxdistexpo,
@@ -44,7 +45,16 @@ public:
                  const vector<enumf> &pruning = vector<enumf>(), bool dual = false,
                  bool subtree_reset = false);
 
-  inline uint64_t get_nodes() const { return nodes; }
+  inline uint64_t get_nodes(const int level = -1) const
+  {
+    if (level == -1)
+    {
+      return std::accumulate(nodes.cbegin(), nodes.cend(), 0);
+    }
+    return nodes[level];
+  }
+
+  inline array<uint64_t, FPLLL_MAX_ENUM_DIM> get_nodes_array() { return nodes; }
 
 private:
   MatGSOInterface<ZT, FT> &_gso;
@@ -70,7 +80,7 @@ template <typename ZT, typename FT> class Enumeration
 public:
   Enumeration(MatGSOInterface<ZT, FT> &gso, Evaluator<FT> &evaluator,
               const vector<int> &max_indices = vector<int>())
-      : _gso(gso), _evaluator(evaluator), _max_indices(max_indices), enumdyn(nullptr), _nodes(0)
+      : _gso(gso), _evaluator(evaluator), _max_indices(max_indices), enumdyn(nullptr), _nodes{}
   {
   }
 
@@ -87,7 +97,7 @@ public:
         enumext.reset(new ExternalEnumeration<ZT, FT>(_gso, _evaluator));
       if (enumext->enumerate(first, last, fmaxdist, fmaxdistexpo, pruning, dual))
       {
-        _nodes = enumext->get_nodes();
+        _nodes = enumext->get_nodes_array();
         return;
       }
     }
@@ -97,10 +107,15 @@ public:
       enumdyn.reset(new EnumerationDyn<ZT, FT>(_gso, _evaluator, _max_indices));
     enumdyn->enumerate(first, last, fmaxdist, fmaxdistexpo, target_coord, subtree, pruning, dual,
                        subtree_reset);
-    _nodes = enumdyn->get_nodes();
+    _nodes = enumdyn->get_nodes_array();
   }
 
-  inline uint64_t get_nodes() const { return _nodes; }
+  inline uint64_t get_nodes(const int level = -1) const
+  {
+    if (level == -1)
+      return std::accumulate(_nodes.begin(), _nodes.end(), 0);
+    return _nodes[level];
+  }
 
 private:
   MatGSOInterface<ZT, FT> &_gso;
@@ -108,7 +123,7 @@ private:
   vector<int> _max_indices;
   std::unique_ptr<EnumerationDyn<ZT, FT>> enumdyn;
   std::unique_ptr<ExternalEnumeration<ZT, FT>> enumext;
-  uint64_t _nodes;
+  array<uint64_t, EnumerationBase::maxdim> _nodes;
 };
 
 FPLLL_END_NAMESPACE

--- a/fplll/enum/enumerate_base.cpp
+++ b/fplll/enum/enumerate_base.cpp
@@ -30,7 +30,7 @@ inline void EnumerationBase::enumerate_recursive(
 
   if (!(newdist <= partdistbounds[kk]))
     return;
-  ++nodes;
+  ++nodes[kk];
 
   alpha[kk] = alphak;
   if (findsubsols && newdist < subsoldists[kk] && newdist != 0.0)
@@ -87,7 +87,7 @@ inline void EnumerationBase::enumerate_recursive(
       enumf newdist2 = partdist[kk] + alphak2 * alphak2 * rdiag[kk];
       if (!(newdist2 <= partdistbounds[kk]))
         return;
-      ++nodes;
+      ++nodes[kk];
       alpha[kk] = alphak2;
       if (kk == 0)
       {
@@ -118,7 +118,7 @@ inline void EnumerationBase::enumerate_recursive(
       enumf newdist2 = partdist[kk] + alphak2 * alphak2 * rdiag[kk];
       if (!(newdist2 <= partdistbounds[kk]))
         return;
-      ++nodes;
+      ++nodes[kk];
       alpha[kk] = alphak2;
       if (kk == 0)
       {
@@ -190,7 +190,7 @@ template <bool dualenum, bool findsubsols, bool enable_reset> void EnumerationBa
 
   partdist[k_end] = 0.0;  // needed to make next_pos_up() work properly
 
-  nodes -= k_end - k;
+  nodes[k_end] -= k_end - k;
   k = k_end - 1;
 
 #ifdef FPLLL_WITH_RECURSIVE_ENUM
@@ -207,7 +207,7 @@ template <bool dualenum, bool findsubsols, bool enable_reset> void EnumerationBa
                            << " newdist=" << newdist << " partdistbounds_k=" << partdistbounds[k]);
     if (newdist <= partdistbounds[k])
     {
-      ++nodes;
+      ++nodes[k];
       alpha[k] = alphak;
       if (findsubsols && newdist < subsoldists[k] && newdist != 0.0)
       {

--- a/fplll/enum/enumerate_base.cpp
+++ b/fplll/enum/enumerate_base.cpp
@@ -190,7 +190,25 @@ template <bool dualenum, bool findsubsols, bool enable_reset> void EnumerationBa
 
   partdist[k_end] = 0.0;  // needed to make next_pos_up() work properly
 
-  nodes[k_end] -= k_end - k;
+  /* The next few lines provide compatibility between the various different enumerators in fplll.
+   * Because the recursive enumerator needs to start at one level down from the last position, we
+   * decrement it. However, this has the tendency of screwing up the node count by a factor of k
+   * (which, although asymptotically shouldn't matter, practically it will). In particular, it has
+   * the property of meaning we count an extra node per level (in k+1....k_end-1) in the initial
+   * descent. You can think of this as fplll just Babai lifting from k_end->k. However, clearly this
+   * may screw up the total - so we adjust this. For more info, see
+   * https://github.com/fplll/fplll/pull/442.
+   *
+   * Note: this adjustment does no checks on the nodes array. This will cause wrap arounds if the
+   * values are 0. But, adding to these later will reset them, so this should  not matter in
+   * practice.
+   */
+
+  for (int i = k + 1; i < k_end; i++)
+  {
+    nodes[i]--;
+  }
+
   k = k_end - 1;
 
 #ifdef FPLLL_WITH_RECURSIVE_ENUM

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -24,6 +24,7 @@
 #include <array>
 #include <cfenv>
 #include <cmath>
+#include <numeric>
 #include <vector>
 
 FPLLL_BEGIN_NAMESPACE
@@ -56,7 +57,15 @@ class EnumerationBase
 public:
   static const int maxdim = FPLLL_MAX_ENUM_DIM;
 
-  inline uint64_t get_nodes() const { return nodes; }
+  inline uint64_t get_nodes(const int level = -1) const
+  {
+    if (level == -1)
+    {
+      return std::accumulate(nodes.begin(), nodes.end(), 0);
+    }
+
+    return nodes[level];
+  }
   virtual ~EnumerationBase() {}
 
 protected:
@@ -88,7 +97,7 @@ protected:
   bool finished;
 
   /* nodes count */
-  uint64_t nodes;
+  array<uint64_t, maxdim> nodes;
 
   template <int kk, int kk_start, bool dualenum, bool findsubsols, bool enable_reset> struct opts
   {

--- a/fplll/enum/enumerate_ext.cpp
+++ b/fplll/enum/enumerate_ext.cpp
@@ -77,7 +77,7 @@ bool ExternalEnumeration<ZT, FT>::enumerate(int first, int last, FT &fmaxdist, l
                _dual, _evaluator.findsubsols
                );
   // clang-format on
-  return _nodes != ~uint64_t(0);
+  return _nodes[0] != ~uint64_t(0);
 }
 
 template <typename ZT, typename FT>

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -84,11 +84,10 @@ typedef void(extenum_cb_process_subsol)(enumf dist, enumf *subsol, int offset);
  *         Or ~uint64_t(0) when instance is not supported
  *         in which case fplll falls back to its own enumeration.
  */
-typedef uint64_t(extenum_fc_enumerate)(const int dim, enumf maxdist,
-                                       std::function<extenum_cb_set_config> cbfunc,
-                                       std::function<extenum_cb_process_sol> cbsol,
-                                       std::function<extenum_cb_process_subsol> cbsubsol,
-                                       bool dual /*=false*/, bool findsubsols /*=false*/
+typedef array<uint64_t, FPLLL_MAX_ENUM_DIM>(extenum_fc_enumerate)(
+    const int dim, enumf maxdist, std::function<extenum_cb_set_config> cbfunc,
+    std::function<extenum_cb_process_sol> cbsol, std::function<extenum_cb_process_subsol> cbsubsol,
+    bool dual /*=false*/, bool findsubsols /*=false*/
 );
 
 /* set & get external enumerator. If extenum = nullptr then this interface is disabled,
@@ -112,7 +111,16 @@ public:
 
   // get_nodes. This returns the number of nodes visited by the external enumeration process.
   // If this returns 0, then fplll will fall back to the internal enumerator.
-  inline uint64_t get_nodes() const { return _nodes; }
+  inline uint64_t get_nodes(const int level = -1) const
+  {
+    if (level == -1)
+    {
+      return std::accumulate(_nodes.begin(), _nodes.end(), 0);
+    }
+    return _nodes[level];
+  }
+
+  inline array<uint64_t, FPLLL_MAX_ENUM_DIM> get_nodes_array() const { return _nodes; }
 
 private:
   void callback_set_config(enumf *mu, size_t mudim, bool mutranspose, enumf *rdiag, enumf *pruning);
@@ -126,7 +134,7 @@ private:
   vector<enumf> _pruning;
   long _normexp;
 
-  uint64_t _nodes;
+  array<uint64_t, FPLLL_MAX_ENUM_DIM> _nodes;
   bool _dual;
   int _d, _first;
   enumf _maxdist;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -42,7 +42,7 @@ AM_CPPFLAGS = -I$(TOPSRCDIR) -I$(TOPSRCDIR)/fplll -I$(TOPBUILDDIR) -DTESTDATADIR
 STAGEDIR := $(realpath -s $(TOPBUILDDIR)/.libs)
 AM_LDFLAGS = -L$(STAGEDIR) -Wl,-rpath,$(STAGEDIR) -lfplll -no-install $(LIBQD_LIBS)
 
-TESTS = test_nr test_lll test_enum test_cvp test_svp test_bkz test_pruner test_sieve test_gso test_lll_gram test_hlll test_svp_gram test_bkz_gram
+TESTS = test_nr test_lll test_enum test_cvp test_svp test_bkz test_pruner test_sieve test_gso test_lll_gram test_hlll test_svp_gram test_bkz_gram test_counter
 
 test_pruner_LDADD=$(LIBQD_LIBS)
 test_sieve_LDADD=$(LIBQD_LIBS)
@@ -60,5 +60,5 @@ test_lll_gram_SOURCES = test_lll_gram.cpp
 test_hlll_SOURCES = test_hlll.cpp
 test_svp_gram_SOURCES = test_svp_gram.cpp
 test_bkz_gram_SOURCES = test_bkz_gram.cpp
-
+test_counter_SOURCES  = test_counter.cpp
 check_PROGRAMS = $(TESTS)

--- a/tests/test_counter.cpp
+++ b/tests/test_counter.cpp
@@ -19,8 +19,7 @@ template <class FT> int test_enum(size_t d)
   max_dist *= 0.99;
   enum_obj.enumerate(0, d, max_dist, 0);
   int status = 0;
-  // Check that we haven't overwritten beyond our bounds
-  status |= (enum_obj.get_nodes(d + 1) != 0);
+
   // Check that we haven't screwed up the sum
   const auto a   = enum_obj.get_nodes_array();
   uint64_t total = 0;
@@ -30,6 +29,13 @@ template <class FT> int test_enum(size_t d)
   }
 
   status |= (total != enum_obj.get_nodes());
+
+  // Check that we haven't overwritten beyond our bounds
+  for (unsigned int i = d + 1; i < a.size(); i++)
+  {
+    status |= (enum_obj.get_nodes(i) != 0);
+  }
+
   return status;
 }
 

--- a/tests/test_counter.cpp
+++ b/tests/test_counter.cpp
@@ -1,0 +1,44 @@
+#include <fplll/fplll.h>
+
+using namespace fplll;
+
+template <class FT> int test_enum(size_t d)
+{
+  RandGen::init_with_seed(0x1337);
+  ZZ_mat<mpz_t> A = ZZ_mat<mpz_t>(100, 100);
+  A.gen_qary_withq(50, 7681);
+  lll_reduction(A);
+  ZZ_mat<mpz_t> U;
+  MatGSO<Z_NR<mpz_t>, FP_NR<FT>> M(A, U, U, 0);
+  M.update_gso();
+
+  FastEvaluator<FP_NR<FT>> evaluator;
+  Enumeration<Z_NR<mpz_t>, FP_NR<FT>> enum_obj(M, evaluator);
+  FP_NR<FT> max_dist;
+  M.get_r(max_dist, 0, 0);
+  max_dist *= 0.99;
+  enum_obj.enumerate(0, d, max_dist, 0);
+  int status = 0;
+  // Check that we haven't overwritten beyond our bounds
+  status |= (enum_obj.get_nodes(d + 1) != 0);
+  // Check that we haven't screwed up the sum
+  const auto a   = enum_obj.get_nodes_array();
+  uint64_t total = 0;
+  for (unsigned int i = 0; i < a.size(); i++)
+  {
+    total += a[i];
+  }
+
+  status |= (total != enum_obj.get_nodes());
+  return status;
+}
+
+int main()
+{
+  int status = 0;
+  // Different, so that we may delegate to either the local enumerator or the
+  // external one.
+  status |= test_enum<double>(10);
+  status |= test_enum<double>(30);
+  return status;
+}


### PR DESCRIPTION
Following #440, this PR changes the counters in fplll from a single, ```uint64_t``` to an array, which contains a counter for each level. 

In particular:
* ```get_nodes()``` has become ```get_nodes(const int level=-1)```. If ```level=-1``` then the sum of all counters is returned.
* ```get_nodes_array()``` now exists. This primarily exists to return the counters from the external enumerator.