### PR TITLE
Added files implementing cvpp functionality within the sieving framew…

### DIFF
--- a/fplll/sieve/sieve_cvpp.cpp
+++ b/fplll/sieve/sieve_cvpp.cpp
@@ -1,0 +1,316 @@
+#include "sieve_gauss.h"
+
+/**
+ * sets the filename for the output
+ */
+string solutions_filename(const char *targets_file_name)
+{
+  string file_name = string(targets_file_name);
+  string old_name;
+  old_name = file_name.substr(0, file_name.find_last_of('.'));
+  return old_name + string("-cvpp_solutions.txt");
+}
+
+/**
+ * imports target vectors from file
+ * Note: the targets are imported without their norm included.
+ */
+template <class ZT> list<ListPoint<ZT> *> target_import(const char *targets_file_name, const int nc)
+{
+  list<ListPoint<ZT> *> target_list;
+  NumVect<Z_NR<ZT>> t_vec(nc);
+  ListPoint<ZT> *p;
+
+  ifstream input_file(targets_file_name);
+  if (!(input_file.is_open()))
+  {
+    cout << "# [ERROR] The input file " << targets_file_name;
+    cout << " was not opened properly. The target(s) were not imported." << endl;
+  }
+  else
+  {
+    p = new_listpoint<ZT>(nc);
+    while (input_file >> t_vec)
+    {
+      p = num_vec_to_list_point(t_vec, nc);
+      if (p->norm > 0)
+        target_list.push_back(p);
+    }
+    input_file.close();
+  }
+  return target_list;
+}
+
+/**
+ * imports List from a file
+ * Note: the list of vectors is imported without their norms
+ */
+template <class ZT, class F>
+void GaussSieve<ZT, F>::import_list_from_file(const char *list_file_name)
+{
+  NumVect<Z_NR<ZT>> t_vec;
+  ListPoint<ZT> *p;
+
+  ifstream input_file(list_file_name);
+  if (!(input_file.is_open()))
+  {
+    cout << "[ERROR] The input file " << list_file_name;
+    cout << " was not opened properly. The list was not imported." << endl;
+  }
+  else
+  {
+    free_list_queue();
+    p = new_listpoint<ZT>(nc);
+    while (input_file >> t_vec)
+    {
+      p = num_vec_to_list_point(t_vec, nc);
+      if (p->norm > 0)
+        List.push_back(p);
+    }
+    input_file.close();
+
+    /* Ensure that the imported list is sorted */
+    List.sort(compare_listpoints<ZT>);
+
+    if (verbose)
+    {
+      cout << "# [info] Imported a list of " << List.size();
+      cout << " lattice vectors from file " << list_file_name << endl;
+    }
+  }
+}
+
+/**
+ * implements the iterative slicer
+ */
+template <class ZT, class F> void GaussSieve<ZT, F>::iterative_slicer(ListPoint<ZT> *target)
+{
+  typename list<ListPoint<ZT> *>::iterator lp_it;
+  ListPoint<ZT> *vc;
+  bool loop = true;
+
+  /* Loop while the target could get reduced */
+  int count = 0;
+  while (loop)
+  {
+    count++;
+    loop = false;
+
+    /* Loop through the list of vectors */
+    for (lp_it = List.begin(); lp_it != List.end(); ++lp_it)
+    {
+      vc = *lp_it;
+      // if ((v->norm) >= 4*(target->norm))
+      //  break;
+
+      /* If there is a reduction the vector should re-pass the list */
+      if (half_2reduce(target, vc))
+      {
+        loop = true;
+        break;
+      }
+    }
+  }
+}
+
+/**
+ * computes the inverse of the base-probability of the
+ * randomised slicer as given in DLW20
+ */
+double dlw20_base(double alpha)
+{
+  int i;
+  double beta, num, base, sq, u, v, x_i, x_i1;
+
+  beta = (alpha * alpha) / (4.0 * (alpha - 1.0));
+  num =
+      ceil(-0.5 + sqrt(pow(4.0 * beta - alpha, 2.0) - 8.0 * (2.0 * beta - alpha)) / (2.0 * alpha));
+
+  if (num == 1)
+  {
+    base = 1.0 / (alpha - pow(alpha + beta - 1.0, 2.0) / (4.0 * beta));
+  }
+  else
+  {
+    sq   = sqrt(pow(alpha * num * num - beta - 1.0, 2.0) + 4.0 * beta * (num * num - 1.0));
+    u    = ((beta + 1.0 - alpha) * num - sq) / (pow(num, 3.0) - num);
+    v    = ((alpha - 2.0 * beta) * pow(num, 2.0) + beta - 1.0 + sq * num) / (pow(num, 3.0) - num);
+    base = 1.0;
+    x_i1 = beta;
+    for (i = 1; i < num + 1; i++)
+    {
+      x_i = u * i * i + v * i + beta;
+      base *= (1.0 / (alpha - pow(alpha + x_i1 - x_i, 2.0) / (4.0 * x_i1)));
+      x_i1 = x_i;
+    }
+  }
+  base = sqrt(base);
+  return base;
+}
+
+/**
+ * implements the randomised slicer
+ */
+template <class ZT, class F>
+void GaussSieve<ZT, F>::randomised_slicer(ListPoint<ZT> *target, const int bound)
+{
+  Z_NR<ZT> dot;
+  NumVect<Z_NR<ZT>> v_rand(nc);
+  ListPoint<ZT> *start_t, *t_red;
+  int i;
+
+  start_t = new_listpoint<ZT>(nc);
+  t_red   = new_listpoint<ZT>(nc);
+
+  clone_listpoint(target, start_t);
+  clone_listpoint(target, t_red);
+
+  /* Call the iterative slicer #bound times */
+  for (i = 0; i < bound; i++)
+  {
+    iterative_slicer(t_red);
+
+    if (t_red->norm < target->norm)
+      clone_listpoint(t_red, target);
+
+    /* Add a random lattice point to the target. */
+    do
+    {
+      v_rand = Sampler->sample();
+      squared_norm(dot, v_rand);
+    } while (dot == 0);
+    (v_rand).add(start_t->v);
+    squared_norm(dot, v_rand);
+    set_listpoint_numvect(v_rand, dot, t_red);
+  }
+
+  del_listpoint(start_t);
+  del_listpoint(t_red);
+}
+
+/**
+ * runs the randomised slicer for a given list of targets
+ * target vector type will interact with the lattice vector type (for now the same)
+ */
+template <class ZT, class F>
+void GaussSieve<ZT, F>::approx_voronoi_cvpp(const char *list_file_name,
+                                            const char *targets_file_name,
+                                            const char *output_list_file)
+{
+  Z_NR<ZT> target_norm;
+  NumVect<Z_NR<ZT>> cvp(nc), t(nc);
+  ListPoint<ZT> *t_red = new_listpoint<ZT>(nc);
+  list<ListPoint<ZT> *> target_list;
+  typename list<ListPoint<ZT> *>::iterator lp_it;
+
+  int bound, targets_num = 0, targets_count;
+  double alpha, expb, base;
+  clock_t stime, etime;
+  double secs = 0;
+
+  /* Import a list or create a list and store it */
+  if (verbose)
+    cout << endl << "# [****] Preprocessing starts..." << endl;
+
+  if (list_file_name != NULL)
+    import_list_from_file(list_file_name);
+  else
+  {
+    target_norm = 0;
+    sieve(target_norm);
+    if (output_list_file != NULL)
+    {
+      print_list_to_file(output_list_file);
+      if (verbose)
+      {
+        cout << "# [info] Created a list of " << List.size();
+        cout << " lattice vectors and stored it in the file " << output_list_file << endl;
+      }
+    }
+  }
+
+  /* Import targets from file */
+  target_list = target_import<ZT>(targets_file_name, nc);
+  targets_num = target_list.size();
+  if (targets_num == 0)
+  {
+    cout << "# [ERROR] No targets given in the file " << targets_file_name << " ." << endl;
+    return;
+  }
+  if (verbose)
+  {
+    cout << endl << "# [****] Query phase starts..." << endl;
+    cout << "# [info] Imported a list of " << targets_num;
+    cout << " target vector(s) from file " << targets_file_name << endl;
+  }
+
+  // debug
+  /*cout << return_first() << endl;
+  for (lp_it = target_list.begin(); lp_it != target_list.end(); ++lp_it)
+  {
+    cout << (*lp_it)->v <<endl;
+  }*/
+
+  /* Obtain a number of rerandomisations based on DLW20 */
+  alpha = pow(List.size(), 2.0 / (double)nr);
+  base  = dlw20_base(alpha);
+  expb  = pow(base, nr);
+  expb *= 20;
+  expb  = fmax(1.0, expb);
+  bound = round(expb);
+
+  /* Run randomised slicer for target(s) */
+  string solution_file = solutions_filename(targets_file_name);
+  ofstream output_file(solution_file);
+
+  targets_count = 1;
+  stime         = clock();
+  for (lp_it = target_list.begin(); lp_it != target_list.end(); ++lp_it)
+  {
+    t_red = *lp_it;
+    t     = t_red->v;
+
+    randomised_slicer(t_red, bound);
+
+    etime = clock();
+    secs  = (etime - stime) / (double)CLOCKS_PER_SEC;
+
+    if (verbose)
+    {
+      cout << "\33[2K\r# [info] Processing targets: " << targets_count << "/" << targets_num;
+      cout << " in " << secs << " s" << flush;
+      targets_count++;
+    }
+
+    /* Print the answer(s) to file */
+    cvp = t;
+    cvp.sub(t_red->v);
+    output_file << cvp << endl;
+
+    // debug
+    /*output_file << "Target vector: " << endl;
+    output_file << t << endl;
+    output_file << "Error vector: " << endl;
+    output_file << (t_red)->v << " ";
+    output_file << (t_red)->norm << endl;
+    output_file << "Closest lattice vector: " << endl;
+    cvp = t;
+    cvp.sub(t_red->v);
+    output_file << cvp << endl << endl;*/
+  }
+  output_file.close();
+
+  if (verbose)
+  {
+    cout << endl;
+    cout << "# [****] done!" << endl;
+    cout << "# [info] Listsize = " << List.size() << endl;
+    cout << "# [info] Number of targets = " << targets_num << endl;
+    cout << "# [info] Number of rerandomisations = 20*2^(" << log2(base) << "*" << nr
+         << ") = " << bound << endl;
+    secs = secs / (double)targets_num;
+    cout << "# [info] Average query time = " << secs << " s" << endl;
+  }
+
+  del_listpoint(t_red);
+}

--- a/fplll/sieve/sieve_gauss.cpp
+++ b/fplll/sieve/sieve_gauss.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "sieve_gauss.h"
+#include "sieve_cvpp.cpp"
 #include "sieve_gauss_2sieve.cpp"
 #include "sieve_gauss_3sieve.cpp"
 #include "sieve_gauss_4sieve.cpp"
@@ -303,6 +304,33 @@ template <class ZT, class F> void GaussSieve<ZT, F>::print_final_info()
 template <class ZT, class F> NumVect<Z_NR<ZT>> GaussSieve<ZT, F>::return_first()
 {
   return List.front()->v;
+}
+
+/**
+ * prints List to a file
+ */
+template <class ZT, class F> void GaussSieve<ZT, F>::print_list_to_file(const char *file_name)
+{
+  typename list<ListPoint<ZT> *>::iterator lp_it;
+  if (file_name != NULL)
+  {
+    ofstream output_file(file_name);
+    if (!(output_file.is_open()))
+    {
+      cout << "[ERROR] The output file " << file_name;
+      cout << " was not opened properly. The list will not be saved." << endl;
+    }
+    else
+    {
+      for (lp_it = List.begin(); lp_it != List.end(); ++lp_it)
+      {
+        output_file << (*lp_it)->v;
+        // output_file << " " << (*lp_it)->norm ;
+        output_file << endl;
+      }
+      output_file.close();
+    }
+  }
 }
 
 template <class ZT, class F> bool GaussSieve<ZT, F>::sieve(Z_NR<ZT> target_norm)

--- a/fplll/sieve/sieve_gauss.h
+++ b/fplll/sieve/sieve_gauss.h
@@ -35,6 +35,9 @@ public:
   vector<long> iters_ls;
 
   NumVect<Z_NR<ZT>> return_first();
+  void print_list_to_file(const char *file_name);
+  void approx_voronoi_cvpp(const char *targets_file_name, const char *list_file_name,
+                           const char *output_list_file);
 
 private:
   int nr, nc;
@@ -86,6 +89,11 @@ private:
   Z_NR<ZT> update_p_4reduce_3reduce(ListPoint<ZT> *p);
   void update_p_4reduce_aux(ListPoint<ZT> *p, typename list<ListPoint<ZT> *>::iterator &lp_it);
   Z_NR<ZT> update_p_4reduce(ListPoint<ZT> *p);
+
+  /* CVPP functions */
+  void import_list_from_file(const char *list_file_name);
+  void iterative_slicer(ListPoint<ZT> *target);
+  void randomised_slicer(ListPoint<ZT> *target, const int bound);
 
   /* info functions */
   void print_curr_info();

--- a/fplll/sieve/sieve_gauss_str.h
+++ b/fplll/sieve/sieve_gauss_str.h
@@ -63,6 +63,14 @@ void set_listpoint_numvect(NumVect<Z_NR<ZT>> a, Z_NR<ZT> norm2, ListPoint<ZT> *p
 template <class ZT> inline void del_listpoint(ListPoint<ZT> *p) { delete p; }
 
 /**
+ * compare two ListPoints according to Euclidean norm
+ */
+template <class ZT> bool compare_listpoints(const ListPoint<ZT> *p1, const ListPoint<ZT> *p2)
+{
+  return (p1->norm < p2->norm);
+}
+
+/**
  * reduce p1 w.r.t to p2
  * (TBA: optimize this function)
  */
@@ -127,14 +135,14 @@ template <class ZT> inline bool half_2reduce(ListPoint<ZT> *p1, const ListPoint<
   t.mul_ui(t, 2);
   t.mul(t, dot);
   (p1->norm).sub(s, t);
-  /*
-  if (debug) {
-    cout << "[debug]  p1new = " << p1->v << endl;
-    cout << "[debug]  |p1new| = " << p1->norm << endl;
-    cout << "[debug]  |v| = " << p2->norm << endl;
-       if (p1->norm <= p2->norm && p1->norm != 0)
-       exit(1);
-  }*/
+/*
+if (debug) {
+  cout << "[debug]  p1new = " << p1->v << endl;
+  cout << "[debug]  |p1new| = " << p1->norm << endl;
+  cout << "[debug]  |v| = " << p2->norm << endl;
+     if (p1->norm <= p2->norm && p1->norm != 0)
+     exit(1);
+}*/
 
 #if 0
   gettimeofday(&time, 0);

--- a/fplll/sieve/sieve_main.cpp
+++ b/fplll/sieve/sieve_main.cpp
@@ -2,6 +2,8 @@
   This provides an implementation of Gauss sieving, including using
   tuples of vectors in fplll framework. The Gauss Sieve code is
   based on Panagiotis Voulgaris's implementation of the Gauss sieve.
+  In addition a CVP(P) functionality is added based on using sieving
+  as the preprocessing.
 */
 #include "sieve_main.h"
 #include "fplll.h"
@@ -25,6 +27,12 @@ static void main_usage(char *myself)
        << "     Using seed=nnn\n"
        << "  -b nnn\n"
        << "     BKZ preprocessing of blocksize=nnn\n"
+       << "  -p filename\n"
+       << "     Output filename for the list\n"
+       << "  -L filename\n"
+       << "     Input filename used for CVPP (includes the list)\n"
+       << "  -C filename\n"
+       << "     Input filename for CVPP (includes the target(s))\n"
        << "  -v\n"
        << "     Verbose mode\n";
 }
@@ -33,10 +41,34 @@ static void main_usage(char *myself)
  * run sieve
  */
 template <class ZT>
-int main_run_sieve(ZZ_mat<ZT> B, Z_NR<ZT> target_norm, int alg, int ver, int seed)
+int main_run_sieve(ZZ_mat<ZT> B, Z_NR<ZT> target_norm, int alg, bool ver, int seed,
+                   char *file_name)  //----
 {
+  clock_t stime = clock(), etime = clock();
+  double secs;
+
   GaussSieve<ZT, FP_NR<double>> gsieve(B, alg, ver, seed);
   gsieve.sieve(target_norm);
+
+  etime = clock();
+  secs  = (etime - stime) / (double)CLOCKS_PER_SEC;
+  if (ver)
+    cout << "# [info] sieve took time " << secs << " s" << endl;
+
+  gsieve.print_list_to_file(file_name);
+  return 0;
+}
+
+/**
+ * run cvpp
+ */
+template <class ZT>
+int main_run_cvpp(ZZ_mat<ZT> B, Z_NR<ZT> target_norm, int alg, bool ver, int seed,
+                  const char *input_list_file, const char *targets_file_name,
+                  const char *output_list_file)
+{
+  GaussSieve<ZT, FP_NR<double>> gsieve(B, alg, ver, seed);
+  gsieve.approx_voronoi_cvpp(input_list_file, targets_file_name, output_list_file);
   return 0;
 }
 
@@ -45,10 +77,14 @@ int main_run_sieve(ZZ_mat<ZT> B, Z_NR<ZT> target_norm, int alg, int ver, int see
  */
 int main(int argc, char **argv)
 {
-  char *input_file_name = NULL;
-  char *target_norm_s   = NULL;
-  bool flag_verbose = true, flag_file = false;
+  char *input_file_name  = NULL;
+  char *target_norm_s    = NULL;
+  char *output_list_file = NULL, *input_list_file = NULL, *targets_file_name = NULL;
+  bool flag_verbose = true, flag_file = false, flag_cvpp = false;
   int option, alg, dim = 10, seed = 0, bs = 0;
+
+// set bool flag_verbose = false; otherwise always true
+// set seed = time(NULL); otherwise the output is the same in every run
 
 #if 0
   dot_time = 0;
@@ -64,7 +100,7 @@ int main(int argc, char **argv)
     main_usage(argv[0]);
     return -1;
   }
-  while ((option = getopt(argc, argv, "a:f:r:t:s:b:v")) != -1)
+  while ((option = getopt(argc, argv, "a:f:r:t:s:b:p:L:C:v")) != -1)
   {
     switch (option)
     {
@@ -92,8 +128,18 @@ int main(int argc, char **argv)
       break;
     case 't':
       // ntarget_norm = atol(optarg);
-      cout << optarg << endl;
+      // cout << optarg << endl;   ---- not necessary ----
       target_norm_s = optarg;
+      break;
+    case 'p':
+      output_list_file = optarg;
+      break;
+    case 'L':
+      input_list_file = optarg;
+      break;
+    case 'C':
+      targets_file_name = optarg;
+      flag_cvpp         = true;
       break;
     case 'h':
       main_usage(argv[0]);
@@ -168,8 +214,7 @@ int main(int argc, char **argv)
   // cout << B << endl;
 
   /* decide integer type */
-  stime = clock();
-  max   = B.get_max();
+  max = B.get_max();
 
 #if 1
   if (max < std::numeric_limits<int>::max())
@@ -181,17 +226,26 @@ int main(int argc, char **argv)
     for (int i = 0; i < B.get_rows(); i++)
       for (int j = 0; j < B.get_cols(); j++)
         B2(i, j) = B(i, j).get_si();
-    main_run_sieve<long>(B2, target_norm_lt, alg, flag_verbose, seed);
+    /* Choose if we solve cvpp or svp */
+    if (flag_cvpp)
+      main_run_cvpp<long>(B2, target_norm_lt, alg, flag_verbose, seed, input_list_file,
+                          targets_file_name, output_list_file);
+    else
+      main_run_sieve<long>(B2, target_norm_lt, alg, flag_verbose, seed, output_list_file);
   }
   else
+  {
 #endif
-    main_run_sieve<mpz_t>(B, target_norm, alg, flag_verbose, seed);
+    /* Choose if we solve cvpp or svp */
+    if (flag_cvpp)
+      main_run_cvpp<mpz_t>(B, target_norm, alg, flag_verbose, seed, input_list_file,
+                           targets_file_name, output_list_file);
+    else
+      main_run_sieve<mpz_t>(B, target_norm, alg, flag_verbose, seed, output_list_file);
+  }
 
-  etime = clock();
-  secs  = (etime - stime) / (double)CLOCKS_PER_SEC;
   if (flag_verbose)
   {
-    cout << "# [info] sieve took time " << secs << " s" << endl;
 /* dot product time */
 #if 0
     cout << "# [info] dot_time " << dot_time << endl;


### PR DESCRIPTION
This pull request includes an implementation of the CVPP functionality. It is a slightly updated version of the implementation used for the CVPP part of the experiments included in the paper: 
Sieve, Enumerate, Slice, and Lift: Hybrid Lattice Algorithms for SVP via CVPP. 

The main part of the new code is included in the file sieve_cvpp.cpp. It implements the iterative slicer and the randomised slicer. The implementation is constructed in the rational that the user gives at least two files as input, one which includes a basis of the lattice and one which includes the target vectors. The list of vectors associated with the preprocessing can either be given as input from a file or can be constructed by the already implemented sieving algorithms. In case the later option is chosen the user can select if he wants the preprocessed list to be stored in a file for later use. Finally the output of the randomised slicer is stored in a file whose name is constructed based on the name of the file containing the target vectors. For example if the target vectors were stored in a file targets.txt the output of the algorithm will be stored in targets-cvpp_solutions.txt

An example call to solve a CVPP would be the following:
latsieve -f basis.txt -L preprocessed_list.txt -C targets1000.txt -v

As the implementation was made within the GaussSieve class the sieve_main.cpp file was also modified in order for the main call to recognise when it is asked to solve SVP or CVPP.