### PR TITLE
Installation from package instructions (fixes #190) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ fplll is available as a pre-built package for a variety of operating systems; th
 
 Below, we give some instructions on how to install these packaged variants of fplll.
 
-Note that these packages will be up-to-date for the most recent version of fplll. However, if you want a feature that has recently been added to master (that is not yet in a release) then it is necessary to build from source (See the "Install from Source" section).
+Note that these packages will be up-to-date for the most recent version of fplll. However, if you want a feature that has recently been added to master (that is not yet in a release) then it is necessary to build from source. If this is the case, please see the [Installation from Source](#installation-from-source) section.
 
 ### Ubuntu and Debian ###
 fplll can be installed directly via Aptitude or Synaptic. Both of these package managers package fplll in the package `fplll-tools`. Therefore, to install this package using Aptitude, run the following command

--- a/README.md
+++ b/README.md
@@ -325,8 +325,9 @@ The options are:
 See [API documentation](https://fplll.github.io/fplll/annotated.html) and [tests](https://github.com/fplll/fplll/tree/master/tests) as a source of examples.
 
 ## Multicore support ##
+This library does not currently use multiple cores and running multiple threads working on the same object `IntegerMatrix`, `LLLReduction`, `MatGSO` etc. is not supported.  Running multiple threads working on *different* objects, however, is supported. That is, there are no global variables and it is safe to e.g. reduce several lattices in parallel in the same process.
 
-This library does not currently use multiple cores and running multiple threads working on the same object `IntegerMatrix`, `LLLReduction`, `MatGSO` etc. is not supported. Running multiple threads working on *different* objects, however, is supported. That is, there are no global variables and it is safe to e.g. reduce several lattices in parallel in the same process.
+As an exception to the above, fplll has an implementation of parallel lattice point enumeration. This implementation is currently used as the default enumeration strategy in fplll. At present fplll does not contain strategies for multi-core pruned enumeration, and so speedups for pruned enumeration may be sub-linear (see [this](https://martinralbrecht.wordpress.com/2020/10/26/multicore-bkz-in-fplll/) for more information). On the other hand, unpruned enumeration appears to scale linearly.
 
 # Examples #
 

--- a/README.md
+++ b/README.md
@@ -30,13 +30,18 @@ fplll is distributed under the [GNU Lesser General Public License](COPYING) (eit
     * [How to cite](#How-to-cite)
   * [Table of contents](#table-of-contents)
   * [Compilation](#compilation)
-    * [Dependencies](#dependencies)
-      * [Required](#required), [Optional](#optional).
-    * [Installation](#installation)
-      * [Linux](#linux)
-      * [Windows 10](#windows-10)
-    * [Optimization](#optimization)
+    * [Installation from packages](#Installation-from-packages)
+    	* [Ubuntu and Debian](#Ubuntu-and-Debian)
+    	* [Conda](#Conda)
+    	* [MacOS](#MacOS)
+    	* [Docker and AWS](#Docker-and-AWS)
+    * [Installation from source](#Installation-from-source)
+    	* [Dependencies](#dependencies)
+      		* [Required](#required), [Optional](#optional).
+      	* [Linux and MacOS](#Linux-and-MacOS)
+      	* [Windows 10](#windows-10)
     * [Check](#check)
+    * [Optimization](#optimization)
   * [How to use](#how-to-use)
     * Programs [latticegen](#latticegen), [fplll](#fplll-1), [llldiff](#llldiff), [latsieve](#latsieve).
     * [How to use as a library](#how-to-use-as-a-library)
@@ -52,27 +57,65 @@ fplll is distributed under the [GNU Lesser General Public License](COPYING) (eit
 
 # Compilation #
 
-## Dependencies ##
+## Installation from packages ##
 
-### Required ###
+fplll is available as a pre-built package for a variety of operating systems; these pre-built packages typically include all mandatory dependencies, and so these packages can be used to start running fplll quickly.
+
+Below, we give some instructions on how to install these packaged variants of fplll.
+
+Note that these packages are likely to be rebuilt every time a new tag is cut; as a result, if you want fully up-to-date code, then it is necessary to build from source (See the "Install from Source" section).
+
+### Ubuntu and Debian ###
+fplll can be installed directly via Aptitude or Synaptic. Both of these package managers package fplll in the package `fplll-tools`. Therefore, to install this package using Aptitude, run the following command
+
+``` 
+sudo aptitude install fplll-tools
+```
+
+If you want to use Synaptic, then you will need to search for the `fplll-tools` package using the search bar.
+
+
+### Conda ###
+fplll can be installed natively as a conda package using the following command
+
+```
+conda install fplll
+```
+
+### MacOS ###
+
+MacOS has a package for fplll inside HomeBrew. Assuming that you have HomeBrew installed, you may install fplll using the following command
+
+```
+brew install fplll
+```
+
+### Docker and AWS ###
+We now have Docker/AWS images for fplll too. They aren't on this repository, though; you can find them [here](https://github.com/malb/fplll-virtual-machines)
+
+## Installation from source ##
+
+fplll can also be built from source. Below, we explicate some of the dependencies for building from source, as well as operating systems specific instructions.
+
+### Dependencies ###
+
+#### Required ####
 
 - GNU MP 4.2.0 or higher [http://gmplib.org/](http://gmplib.org/) or MPIR 1.0.0 or higher [http://mpir.org](http://mpir.org)
 - MPFR 2.3.0 or higher, COMPLETE INSTALLATION [http://www.mpfr.org/](http://www.mpfr.org/)
 - autotools 2.61 or higher
 - g++ 4.9.3 or higher
 
-### Optional ###
+#### Optional ####
 - QD 2.3.15 or higher (a C++/Fortran-90 double-double and quad-double package), compile and install
   the shared library (e.g. `./configure --enable-shared=yes`).
   [http://crd-legacy.lbl.gov/~dhbailey/mpdist/](http://crd-legacy.lbl.gov/~dhbailey/mpdist/)
   
 NOTE: If you are intending to use fplll on Windows 10, then these packages are not required before you get started. This is because you use fplll via the "Windows Subsystem for Linux". Please go straight to the instructions for [Windows 10](#windows-10).
 
-## Installation ##
+### Linux and MacOS ###
 
-### Linux ###
-
-You should downloaded the source code from github and then run
+You should download the source code from Github and then run
 
     ./autogen.sh
 
@@ -105,11 +148,11 @@ installation directory name other than `/usr/local` by giving `./configure` the 
 
 ### Windows 10 ###
 
-Windows 10 has a "Windows Subsystem for Linux", which essentially allows you to use Linux features in Windows without the need for a dual-boot system or a virtual machine. To activate this, first go to **Settings** -> **Update and security** -> **For developers** and enable developer mode. (This may take a while.) Afterwards, open Powershell as an administrator and run 
+Windows 10 has the "Windows Subsystem for Linux", which essentially allows you to use Linux features in Windows without the need for a dual-boot system or a virtual machine. To activate this, first go to **Settings** -> **Update and security** -> **For developers** and enable developer mode. (This may take a while.) Afterwards, open Powershell as an administrator and run 
 
 	Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
 
-This will enable the WSL. Next, open the Windows Store and navigate to your favourite available Linux distribution - this may be installed as if were a regular application. Afterwards, this system can be accessed as if it were a regular program e.g. by opening command prompt and typing `bash`. With this Linux-like subsystem, installing fplll is then similar to above, except that most likely the package repository is not up to date, and various additional packages need to be installed first. To make sure you only install the most recent software, run:
+This will enable the WSL. Next, open the Windows Store and navigate to your favourite available Linux distribution - this may be installed as if it were a regular application. Afterwards, this system will act as a regular program, and so it can be opened however you like e.g. by opening command prompt and typing `bash`. With this Linux-like subsystem, installing fplll is then similar to above, except that most likely the package repository is not up to date, and various additional packages need to be installed first. To make sure you only install the most recent software, run:
 	
 	sudo apt-get update
 	

--- a/README.md
+++ b/README.md
@@ -327,7 +327,10 @@ See [API documentation](https://fplll.github.io/fplll/annotated.html) and [tests
 ## Multicore support ##
 This library does not currently use multiple cores and running multiple threads working on the same object `IntegerMatrix`, `LLLReduction`, `MatGSO` etc. is not supported.  Running multiple threads working on *different* objects, however, is supported. That is, there are no global variables and it is safe to e.g. reduce several lattices in parallel in the same process.
 
-As an exception to the above, fplll has an implementation of parallel lattice point enumeration. This implementation is currently used as the default enumeration strategy in fplll. At present fplll does not contain strategies for multi-core pruned enumeration, and so speedups for pruned enumeration may be sub-linear (see [this](https://martinralbrecht.wordpress.com/2020/10/26/multicore-bkz-in-fplll/) for more information). On the other hand, unpruned enumeration appears to scale linearly.
+As an exception to the above, fplll has an implementation of parallel lattice point enumeration. 
+To enable this implementation, make sure you compile with the maximum parallel enumeration dimension greater than 0. Note that increasing this value will increase the compile-time due to the use of templates.
+
+At present fplll does not contain strategies for multi-core pruned enumeration, and so speedups for pruned enumeration may be sub-linear (see [this](https://martinralbrecht.wordpress.com/2020/10/26/multicore-bkz-in-fplll/) for more information). On the other hand, unpruned enumeration appears to scale linearly.
 
 # Examples #
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ fplll is available as a pre-built package for a variety of operating systems; th
 
 Below, we give some instructions on how to install these packaged variants of fplll.
 
-Note that these packages are likely to be rebuilt every time a new tag is cut; as a result, if you want fully up-to-date code, then it is necessary to build from source (See the "Install from Source" section).
+Note that these packages will be up-to-date for the most recent version of fplll. However, if you want a feature that has recently been added to master (that is not yet in a release) then it is necessary to build from source (See the "Install from Source" section).
 
 ### Ubuntu and Debian ###
 fplll can be installed directly via Aptitude or Synaptic. Both of these package managers package fplll in the package `fplll-tools`. Therefore, to install this package using Aptitude, run the following command

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ fplll can also be built from source. Below, we explicate some of the dependencie
   the shared library (e.g. `./configure --enable-shared=yes`).
   [http://crd-legacy.lbl.gov/~dhbailey/mpdist/](http://crd-legacy.lbl.gov/~dhbailey/mpdist/)
   
-NOTE: If you are intending to use fplll on Windows 10, then these packages are not required before you get started. This is because you use fplll via the "Windows Subsystem for Linux". Please go straight to the instructions for [Windows 10](#windows-10).
+NOTE: If you are intending to use fplll on Windows 10, then these packages should be installed after the `Windows Subsystem for Linux` has been installed and activated. Please go to the [Windows 10](#windows-10) instructions for more information.
 
 ### Linux and MacOS ###
 
@@ -148,7 +148,7 @@ installation directory name other than `/usr/local` by giving `./configure` the 
 
 ### Windows 10 ###
 
-Windows 10 has the "Windows Subsystem for Linux", which essentially allows you to use Linux features in Windows without the need for a dual-boot system or a virtual machine. To activate this, first go to **Settings** -> **Update and security** -> **For developers** and enable developer mode. (This may take a while.) Afterwards, open Powershell as an administrator and run 
+Windows 10 has the "Windows Subsystem for Linux"(WSL), which essentially allows you to use Linux features in Windows without the need for a dual-boot system or a virtual machine. To activate this, first go to **Settings** -> **Update and security** -> **For developers** and enable developer mode. (This may take a while.) Afterwards, open Powershell as an administrator and run 
 
 	Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ brew install fplll
 ```
 
 ### Docker and AWS ###
-We now have Docker/AWS images for fplll too. They aren't on this repository, though; you can find them [here](https://github.com/malb/fplll-virtual-machines)
+We now have Docker/AWS images for fplll too. They aren't on this repository, though; you can find them [here](https://hub.docker.com/u/fplll)
 
 ## Installation from source ##
 


### PR DESCRIPTION
We can install fplll in multiple ways. Shouldn't the readme talk about this?

## This PR:
This PR attempts to close a long-standing issue (#190) that pertains to describing some different ways to install fplll from pre-built packages. In particular, this PR describes how to install fplll from packages on the following platforms:

- Ubuntu and Debian
- MacOS
- Conda
- Docker.

It also makes some small wording changes to the WSL section (just small tweaks to my own wording from fplll days 5). This should make the readme clearer.

## What needs to be done?
I've checked all of the instructions but the Docker ones (this simply refers the user to the repository with the Docker images); these all work . 

It's possible though that I've screwed something up, and I'd appreciate it if someone could check at least some subset of these instructions! 
