### PR TITLE
Set a default external enumeration library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -188,7 +188,7 @@ AM_CONDITIONAL(FPLLL_PARALLEL_ENUM, test "x$max_parallel_enum_dim" != "x0")
 # Use external enumeration
 AC_ARG_WITH(extenum-dir,
   AS_HELP_STRING([--with-extenum-dir@<:@=DIR@:>@], [Specify external enumeration library install directory]),
-  [extenum_dir=$withval])
+  [LDFLAGS="$LDFLAGS -L$withval"])
 AC_ARG_WITH(extenum-lib,
   AS_HELP_STRING([--with-extenum-lib@<:@=FILE@:>@], [Specify external enumeration library name]),
   [extenum_lib=$withval])
@@ -198,8 +198,13 @@ AC_ARG_WITH(extenum-func,
 AS_IF([test "x$extenum_lib" != "x"],[
   AS_IF([test "x$extenum_func" != "x"],[
       AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM([#include "fplll/enum/enumeration_ext.h"],[extenum_fc_enumerate $extenum_func; auto abc = & $extenum_func;])],,AC_MSG_ERROR([Failed to find external enumeration]))
-      EXTENUM_LIBS="-L$extenum_dir -l$extenum_lib"
+        [AC_LANG_PROGRAM([
+          #include "fplll/enum/enumerate_ext_api.h"
+          extern extenum_fc_enumerate $extenum_func;
+        ],[
+          auto abc = & $extenum_func;
+        ])],,AC_MSG_ERROR([Failed to find external enumeration]))
+      EXTENUM_LIBS="-l$extenum_lib"
       AC_DEFINE_UNQUOTED([FPLLL_EXTENUM_FUNC], $extenum_func, [use external enumeration function])
   ])
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -196,17 +196,17 @@ AC_ARG_WITH(extenum-func,
   AS_HELP_STRING([--with-extenum-func@<:@=FUNC@:>@], [Specify external enumeration function name]),
   [extenum_func=$withval])
 AS_IF([test "x$extenum_lib" != "x"],[
-  AS_IF([test "x$extenum_func" != "x"],[
-      AC_LINK_IFELSE(
-        [AC_LANG_PROGRAM([
+  AS_IF([test "x$extenum_func" != "x"],,[extenum_func=$extenum_lib])
+  AC_LINK_IFELSE(
+    [AC_LANG_PROGRAM([
           #include "fplll/enum/enumerate_ext_api.h"
           extern extenum_fc_enumerate $extenum_func;
-        ],[
+    ],[
           auto abc = & $extenum_func;
-        ])],,AC_MSG_ERROR([Failed to find external enumeration]))
-      EXTENUM_LIBS="-l$extenum_lib"
-      AC_DEFINE_UNQUOTED([FPLLL_EXTENUM_FUNC], $extenum_func, [use external enumeration function])
-  ])
+    ])]
+    ,,AC_MSG_ERROR([Failed to find external enumeration]))
+  EXTENUM_LIBS="-l$extenum_lib"
+  AC_DEFINE_UNQUOTED([FPLLL_EXTENUM_FUNC], $extenum_func, [use external enumeration function])
 ])
 AC_SUBST(EXTENUM_LIBS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,26 @@ AC_ARG_WITH(max-parallel-enum-dim,
 AC_DEFINE_UNQUOTED([FPLLL_MAX_PARALLEL_ENUM_DIM], $max_parallel_enum_dim, [parallel enumeration enabled])
 AM_CONDITIONAL(FPLLL_PARALLEL_ENUM, test "x$max_parallel_enum_dim" != "x0")
 
+# Use external enumeration
+AC_ARG_WITH(extenum-dir,
+  AS_HELP_STRING([--with-extenum-dir@<:@=DIR@:>@], [Specify external enumeration library install directory]),
+  [extenum_dir=$withval])
+AC_ARG_WITH(extenum-lib,
+  AS_HELP_STRING([--with-extenum-lib@<:@=FILE@:>@], [Specify external enumeration library name]),
+  [extenum_lib=$withval])
+AC_ARG_WITH(extenum-func,
+  AS_HELP_STRING([--with-extenum-func@<:@=FUNC@:>@], [Specify external enumeration function name]),
+  [extenum_func=$withval])
+AS_IF([test "x$extenum_lib" != "x"],[
+  AS_IF([test "x$extenum_func" != "x"],[
+      AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([#include "fplll/enum/enumeration_ext.h"],[extenum_fc_enumerate $extenum_func; auto abc = & $extenum_func;])],,AC_MSG_ERROR([Failed to find external enumeration]))
+      EXTENUM_LIBS="-L$extenum_dir -l$extenum_lib"
+      AC_DEFINE_UNQUOTED([FPLLL_EXTENUM_FUNC], $extenum_func, [use external enumeration function])
+  ])
+])
+AC_SUBST(EXTENUM_LIBS)
+
 # Store version numbers in header
 
 AC_DEFINE_UNQUOTED([FPLLL_MAJOR_VERSION],[$FPLLL_MAJOR_VERSION],[major version])

--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -107,7 +107,7 @@ libfplll_la_SOURCES=fplll.cpp fplll.h \
 libfplll_la_CXXFLAGS=$(PTHREAD_CFLAGS)
 
 EXTRA_libfplll_la_SOURCES= svpcvp.cpp
-libfplll_la_LIBADD=$(LIBQD_LIBS) $(PTHREAD_LIBS)
+libfplll_la_LIBADD=$(LIBQD_LIBS) $(PTHREAD_LIBS) $(EXTENUM_LIBS)
 libfplll_la_LDFLAGS=-no-undefined -version-info @FPLLL_LT_CURRENT@:@FPLLL_LT_REVISION@:@FPLLL_LT_AGE@ $(PTHREAD_CFLAGS)
 
 if FPLLL_PARALLEL_ENUM

--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -34,7 +34,7 @@ nobase_include_fplll_HEADERS=defs.h fplll.h \
 	enum/evaluator.h \
 	wrapper.h \
 	bkz_param.h \
-	enum/enumerate.h enum/enumerate_base.h enum/enumerate_ext.h \
+	enum/enumerate.h enum/enumerate_base.h enum/enumerate_ext.h enum/enumerate_ext_api.h \
 	sieve/sieve_gauss.h sieve/sieve_common.h sieve/sieve_gauss_str.h sieve/sampler_basic.h \
 	pruner/pruner.h pruner/pruner_simplex.h \
 	householder.h hlll.h \
@@ -76,7 +76,7 @@ libfplll_la_SOURCES=fplll.cpp fplll.h \
 	enum/topenum.cpp enum/topenum.h \
 	enum/enumerate.cpp enum/enumerate.h \
 	enum/enumerate_base.cpp enum/enumerate_base.h \
-	enum/enumerate_ext.cpp enum/enumerate_ext.h \
+	enum/enumerate_ext.cpp enum/enumerate_ext.h enum/enumerate_ext_api.h \
 	enum/evaluator.cpp enum/evaluator.h \
 	lll.cpp lll.h \
 	wrapper.cpp wrapper.h \

--- a/fplll/enum-parallel/enumlib.cpp
+++ b/fplll/enum-parallel/enumlib.cpp
@@ -39,7 +39,7 @@ enumlib_enumerate(int dim, fplll::enumf maxdist, std::function<fplll::extenum_cb
                   bool findsubsols);
 
 #define ENUMFUNCNAME(DIM)                                                                          \
-  std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> enumerate##DIM(                                              \
+  std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> enumerate##DIM(                              \
       int, float_type, std::function<extenum_cb_set_config>,                                       \
       std::function<extenum_cb_process_sol>, std::function<extenum_cb_process_subsol>, bool,       \
       bool);

--- a/fplll/enum-parallel/enumlib.cpp
+++ b/fplll/enum-parallel/enumlib.cpp
@@ -32,16 +32,14 @@ FPLLL_BEGIN_NAMESPACE
 namespace enumlib
 {
 
-using namespace std;
-
-array<uint64_t, FPLLL_MAX_ENUM_DIM>
+std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM>
 enumlib_enumerate(int dim, fplll::enumf maxdist, std::function<fplll::extenum_cb_set_config> cbfunc,
                   std::function<fplll::extenum_cb_process_sol> cbsol,
                   std::function<fplll::extenum_cb_process_subsol> cbsubsol, bool dual,
                   bool findsubsols);
 
 #define ENUMFUNCNAME(DIM)                                                                          \
-  array<uint64_t, FPLLL_MAX_ENUM_DIM> enumerate##DIM(                                              \
+  std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> enumerate##DIM(                                              \
       int, float_type, std::function<extenum_cb_set_config>,                                       \
       std::function<extenum_cb_process_sol>, std::function<extenum_cb_process_subsol>, bool,       \
       bool);
@@ -92,7 +90,7 @@ ENUMFUNCNAME(150);
 ENUMFUNCNAME(160);
 #endif
 
-array<uint64_t, FPLLL_MAX_ENUM_DIM>
+std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM>
 enumlib_enumerate(int dim, fplll_float maxdist, std::function<extenum_cb_set_config> cbfunc,
                   std::function<extenum_cb_process_sol> cbsol,
                   std::function<extenum_cb_process_subsol> cbsubsol, bool dual, bool findsubsols)
@@ -100,7 +98,7 @@ enumlib_enumerate(int dim, fplll_float maxdist, std::function<extenum_cb_set_con
   // dual svp enumeration not supported yet
   if (dim <= 10 || dual)
   {
-    array<uint64_t, FPLLL_MAX_ENUM_DIM> out;
+    std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> out;
     out[0] = ~uint64_t(0);
     return out;
   }
@@ -165,7 +163,7 @@ enumlib_enumerate(int dim, fplll_float maxdist, std::function<extenum_cb_set_con
   if (dim <= 160)
     return enumerate160(dim, maxdist, cbfunc, cbsol, cbsubsol, dual, findsubsols);
 #endif
-  array<uint64_t, FPLLL_MAX_ENUM_DIM> out;
+  std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> out;
   out[0] = ~uint64_t(0);
   return out;
 }

--- a/fplll/enum-parallel/enumlib.h
+++ b/fplll/enum-parallel/enumlib.h
@@ -27,13 +27,14 @@ SOFTWARE.
 
 #include "fplll_types.h"
 #include <fplll/defs.h>
+#include <fplll/enum/enumerate_ext_api.h>
 
 FPLLL_BEGIN_NAMESPACE
 
 namespace enumlib
 {
 
-array<uint64_t, FPLLL_MAX_ENUM_DIM> enumlib_enumerate(
+std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> enumlib_enumerate(
     int dim, ::fplll::enumf maxdist, std::function<::fplll::extenum_cb_set_config> cbfunc,
     std::function<::fplll::extenum_cb_process_sol> cbsol,
     std::function<::fplll::extenum_cb_process_subsol> cbsubsol, bool dual, bool findsubsols);

--- a/fplll/enum-parallel/enumlib_dim.cpp
+++ b/fplll/enum-parallel/enumlib_dim.cpp
@@ -35,6 +35,8 @@ FPLLL_BEGIN_NAMESPACE
 namespace enumlib
 {
 
+using namespace std;
+
 template <int dimension> struct enumerate_traits
 {
   static const int SWIRLY          = 1 + (dimension / 20);
@@ -43,7 +45,7 @@ template <int dimension> struct enumerate_traits
 };
 
 template <int dimension, bool findsubsols>
-array<uint64_t, FPLLL_MAX_ENUM_DIM>
+array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM>
 enumerate_dim_detail(int dim, float_type maxdist,
                      std::function<extenum_cb_set_config> cb_set_config,
                      std::function<extenum_cb_process_sol> cb_process_sol,
@@ -81,13 +83,13 @@ enumerate_dim_detail(int dim, float_type maxdist,
   static_assert(FPLLL_MAX_ENUM_DIM > dimension,
                 "The maximum enumeration dimension needs to be bigger than, or equal to, the "
                 "parallel enumeration dim");
-  array<uint64_t, FPLLL_MAX_ENUM_DIM> arr{};
+  array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> arr{};
   std::copy(lat._counts.cbegin(), lat._counts.cend(), arr.begin());
   return arr;
 }
 
 template <int dimension>
-array<uint64_t, FPLLL_MAX_ENUM_DIM>
+array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM>
 enumerate_dim(int dim, float_type maxdist, std::function<extenum_cb_set_config> cb_set_config,
               std::function<extenum_cb_process_sol> cb_process_sol,
               std::function<extenum_cb_process_subsol> cb_process_subsol, bool dual,
@@ -112,7 +114,7 @@ enumerate_dim(int dim, float_type maxdist, std::function<extenum_cb_set_config> 
                               dual, findsubsols);                                                  \
     break;
 
-array<uint64_t, FPLLL_MAX_ENUM_DIM> DIMFUNC(ENUMDIMENSION)(
+array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> DIMFUNC(ENUMDIMENSION)(
     int dim, float_type maxdist, std::function<extenum_cb_set_config> cb_set_config,
     std::function<extenum_cb_process_sol> cb_process_sol,
     std::function<extenum_cb_process_subsol> cb_process_subsol, bool dual, bool findsubsols)
@@ -133,7 +135,7 @@ array<uint64_t, FPLLL_MAX_ENUM_DIM> DIMFUNC(ENUMDIMENSION)(
   }
 
   cout << "[enumlib] " << ENUMDIMENSION << ":" << dim << " wrong dimension!" << endl;
-  array<uint64_t, FPLLL_MAX_ENUM_DIM> arr{};
+  std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> arr{};
   arr[0] = ~uint64_t(0);
   return arr;
 }

--- a/fplll/enum/enumerate.h
+++ b/fplll/enum/enumerate.h
@@ -54,7 +54,7 @@ public:
     return nodes[level];
   }
 
-  inline array<uint64_t, FPLLL_MAX_ENUM_DIM> get_nodes_array() { return nodes; }
+  inline array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> get_nodes_array() { return nodes; }
 
 private:
   MatGSOInterface<ZT, FT> &_gso;
@@ -117,7 +117,7 @@ public:
     return _nodes[level];
   }
 
-  inline array<uint64_t, EnumerationBase::maxdim> get_nodes_array() const { return _nodes; }
+  inline array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> get_nodes_array() const { return _nodes; }
 
 private:
   MatGSOInterface<ZT, FT> &_gso;
@@ -125,7 +125,7 @@ private:
   vector<int> _max_indices;
   std::unique_ptr<EnumerationDyn<ZT, FT>> enumdyn;
   std::unique_ptr<ExternalEnumeration<ZT, FT>> enumext;
-  array<uint64_t, EnumerationBase::maxdim> _nodes;
+  array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> _nodes;
 };
 
 FPLLL_END_NAMESPACE

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -19,9 +19,9 @@
 #ifndef FPLLL_ENUMERATE_BASE_H
 #define FPLLL_ENUMERATE_BASE_H
 
+#include "fplll/enum/enumerate_ext_api.h"
 #include "fplll/fplll_config.h"
 #include "fplll/nr/nr.h"
-#include "fplll/enum/enumerate_ext_api.h"
 #include <array>
 #include <cfenv>
 #include <cmath>

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -21,6 +21,7 @@
 
 #include "fplll/fplll_config.h"
 #include "fplll/nr/nr.h"
+#include "fplll/enum/enumerate_ext_api.h"
 #include <array>
 #include <cfenv>
 #include <cmath>
@@ -97,7 +98,7 @@ protected:
   bool finished;
 
   /* nodes count */
-  array<uint64_t, maxdim> nodes;
+  array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> nodes;
 
   template <int kk, int kk_start, bool dualenum, bool findsubsols, bool enable_reset> struct opts
   {

--- a/fplll/enum/enumerate_ext.cpp
+++ b/fplll/enum/enumerate_ext.cpp
@@ -21,13 +21,21 @@
 #include "../enum-parallel/enumlib.h"
 #endif
 
+#ifdef FPLLL_EXTENUM_FUNC
+extern extenum_fc_enumerate FPLLL_EXTENUM_FUNC;
+#endif
+
 FPLLL_BEGIN_NAMESPACE
 
 // set & get external enumerator (nullptr => disabled)
+#ifdef FPLLL_EXTENUM_FUNC
+std::function<extenum_fc_enumerate> fplll_extenum = FPLLL_EXTENUM_FUNC;
+#else
 #if FPLLL_MAX_PARALLEL_ENUM_DIM != 0
 std::function<extenum_fc_enumerate> fplll_extenum = enumlib::enumlib_enumerate;
 #else
 std::function<extenum_fc_enumerate> fplll_extenum = nullptr;
+#endif
 #endif
 
 void set_external_enumerator(std::function<extenum_fc_enumerate> extenum)

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -49,7 +49,7 @@ FPLLL_BEGIN_NAMESPACE
  * contain the pruning coefficients for enumeration. In rigorous enumeration, this array will
  * consist solely of 1's.
  */
-//typedef void(extenum_cb_set_config)(enumf *mu, size_t mudim, bool mutranspose, enumf *rdiag,
+// typedef void(extenum_cb_set_config)(enumf *mu, size_t mudim, bool mutranspose, enumf *rdiag,
 //                                    enumf *pruning);
 using ::extenum_cb_set_config;
 
@@ -60,7 +60,7 @@ using ::extenum_cb_set_config;
  * @param[in] sol - a pointer to the new solution.
  * @return The new enumeration bound.
  */
-//typedef enumf(extenum_cb_process_sol)(enumf dist, enumf *sol);
+// typedef enumf(extenum_cb_process_sol)(enumf dist, enumf *sol);
 using ::extenum_cb_process_sol;
 
 /**
@@ -68,7 +68,7 @@ using ::extenum_cb_process_sol;
  *
  * Pass a subsolution and its partial length to Evaluator.
  */
-//typedef void(extenum_cb_process_subsol)(enumf dist, enumf *subsol, int offset);
+// typedef void(extenum_cb_process_subsol)(enumf dist, enumf *subsol, int offset);
 using ::extenum_cb_process_subsol;
 
 /**
@@ -86,10 +86,10 @@ using ::extenum_cb_process_subsol;
  *         Or ~uint64_t(0) when instance is not supported
  *         in which case fplll falls back to its own enumeration.
  */
-//typedef array<uint64_t, FPLLL_MAX_ENUM_DIM>(extenum_fc_enumerate)(
+// typedef array<uint64_t, FPLLL_MAX_ENUM_DIM>(extenum_fc_enumerate)(
 //    const int dim, enumf maxdist, std::function<extenum_cb_set_config> cbfunc,
-//    std::function<extenum_cb_process_sol> cbsol, std::function<extenum_cb_process_subsol> cbsubsol,
-//    bool dual /*=false*/, bool findsubsols /*=false*/
+//    std::function<extenum_cb_process_sol> cbsol, std::function<extenum_cb_process_subsol>
+//    cbsubsol, bool dual /*=false*/, bool findsubsols /*=false*/
 //);
 using ::extenum_fc_enumerate;
 

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -17,12 +17,11 @@
 #ifndef FPLLL_ENUMERATE_EXT_H
 #define FPLLL_ENUMERATE_EXT_H
 
-#include <array>
+#include "enumerate_ext_api.h"
+
 #include <fplll/enum/enumerate_base.h>
 #include <fplll/enum/evaluator.h>
 #include <fplll/gso_interface.h>
-#include <functional>
-#include <memory>
 
 FPLLL_BEGIN_NAMESPACE
 
@@ -50,8 +49,9 @@ FPLLL_BEGIN_NAMESPACE
  * contain the pruning coefficients for enumeration. In rigorous enumeration, this array will
  * consist solely of 1's.
  */
-typedef void(extenum_cb_set_config)(enumf *mu, size_t mudim, bool mutranspose, enumf *rdiag,
-                                    enumf *pruning);
+//typedef void(extenum_cb_set_config)(enumf *mu, size_t mudim, bool mutranspose, enumf *rdiag,
+//                                    enumf *pruning);
+using ::extenum_cb_set_config;
 
 /**
  * Callback function given to external enumeration library.
@@ -60,14 +60,16 @@ typedef void(extenum_cb_set_config)(enumf *mu, size_t mudim, bool mutranspose, e
  * @param[in] sol - a pointer to the new solution.
  * @return The new enumeration bound.
  */
-typedef enumf(extenum_cb_process_sol)(enumf dist, enumf *sol);
+//typedef enumf(extenum_cb_process_sol)(enumf dist, enumf *sol);
+using ::extenum_cb_process_sol;
 
 /**
  * Callback function given to external enumeration library.
  *
  * Pass a subsolution and its partial length to Evaluator.
  */
-typedef void(extenum_cb_process_subsol)(enumf dist, enumf *subsol, int offset);
+//typedef void(extenum_cb_process_subsol)(enumf dist, enumf *subsol, int offset);
+using ::extenum_cb_process_subsol;
 
 /**
  * External enumeration function prototype.
@@ -84,11 +86,12 @@ typedef void(extenum_cb_process_subsol)(enumf dist, enumf *subsol, int offset);
  *         Or ~uint64_t(0) when instance is not supported
  *         in which case fplll falls back to its own enumeration.
  */
-typedef array<uint64_t, FPLLL_MAX_ENUM_DIM>(extenum_fc_enumerate)(
-    const int dim, enumf maxdist, std::function<extenum_cb_set_config> cbfunc,
-    std::function<extenum_cb_process_sol> cbsol, std::function<extenum_cb_process_subsol> cbsubsol,
-    bool dual /*=false*/, bool findsubsols /*=false*/
-);
+//typedef array<uint64_t, FPLLL_MAX_ENUM_DIM>(extenum_fc_enumerate)(
+//    const int dim, enumf maxdist, std::function<extenum_cb_set_config> cbfunc,
+//    std::function<extenum_cb_process_sol> cbsol, std::function<extenum_cb_process_subsol> cbsubsol,
+//    bool dual /*=false*/, bool findsubsols /*=false*/
+//);
+using ::extenum_fc_enumerate;
 
 /* set & get external enumerator. If extenum = nullptr then this interface is disabled,
                                   and fplll will use the internal enumerator.

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -123,7 +123,10 @@ public:
     return _nodes[level];
   }
 
-  inline std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> get_nodes_array() const { return _nodes; }
+  inline std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> get_nodes_array() const
+  {
+    return _nodes;
+  }
 
 private:
   void callback_set_config(enumf *mu, size_t mudim, bool mutranspose, enumf *rdiag, enumf *pruning);

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -86,7 +86,7 @@ using ::extenum_cb_process_subsol;
  *         Or ~uint64_t(0) when instance is not supported
  *         in which case fplll falls back to its own enumeration.
  */
-// typedef array<uint64_t, FPLLL_MAX_ENUM_DIM>(extenum_fc_enumerate)(
+// typedef array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM>(extenum_fc_enumerate)(
 //    const int dim, enumf maxdist, std::function<extenum_cb_set_config> cbfunc,
 //    std::function<extenum_cb_process_sol> cbsol, std::function<extenum_cb_process_subsol>
 //    cbsubsol, bool dual /*=false*/, bool findsubsols /*=false*/
@@ -123,7 +123,7 @@ public:
     return _nodes[level];
   }
 
-  inline array<uint64_t, FPLLL_MAX_ENUM_DIM> get_nodes_array() const { return _nodes; }
+  inline std::array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> get_nodes_array() const { return _nodes; }
 
 private:
   void callback_set_config(enumf *mu, size_t mudim, bool mutranspose, enumf *rdiag, enumf *pruning);
@@ -137,7 +137,7 @@ private:
   vector<enumf> _pruning;
   long _normexp;
 
-  array<uint64_t, FPLLL_MAX_ENUM_DIM> _nodes;
+  array<uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM> _nodes;
   bool _dual;
   int _d, _first;
   enumf _maxdist;

--- a/fplll/enum/enumerate_ext_api.h
+++ b/fplll/enum/enumerate_ext_api.h
@@ -22,7 +22,7 @@
 #include <memory>
 
 typedef double fplll_extenum_enumf;
-#define FPLLL_EXTENUM_MAX_EXTENUM_DIM 256
+#define FPLLL_EXTENUM_MAX_EXTENUM_DIM 1024
 
 /* function callback API for external enumeration library (extenum) */
 

--- a/fplll/enum/enumerate_ext_api.h
+++ b/fplll/enum/enumerate_ext_api.h
@@ -22,7 +22,7 @@
 #include <memory>
 
 typedef double fplll_extenum_enumf;
-#define FPLLL_EXTENUM_MAX_EXTENUM_DIM 256;
+#define FPLLL_EXTENUM_MAX_EXTENUM_DIM 256
 
 /* function callback API for external enumeration library (extenum) */
 

--- a/fplll/enum/enumerate_ext_api.h
+++ b/fplll/enum/enumerate_ext_api.h
@@ -1,0 +1,91 @@
+/*
+   (C) 2016 Marc Stevens.
+
+   This file is part of fplll. fplll is free software: you
+   can redistribute it and/or modify it under the terms of the GNU Lesser
+   General Public License as published by the Free Software Foundation,
+   either version 2.1 of the License, or (at your option) any later version.
+
+   fplll is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+   GNU Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public License
+   along with fplll. If not, see <http://www.gnu.org/licenses/>. */
+
+#ifndef FPLLL_ENUMERATE_EXT_API_H
+#define FPLLL_ENUMERATE_EXT_API_H
+
+#include <array>
+#include <functional>
+#include <memory>
+
+typedef double fplll_extenum_enumf;
+#define FPLLL_EXTENUM_MAX_EXTENUM_DIM 256;
+
+/* function callback API for external enumeration library (extenum) */
+
+/**
+ * Callback function given to external enumeration library.
+ *
+ * @param[out] mu - this is a pointer to an array 'enumf mu[mudim][mudim]'.
+ * 	       Upon return, this array will contain
+ * 	       the mu values for the lattice basis.
+ * 	       Note that the array pointed to by this argument needs to be contiguous,
+ * 	       otherwise there will be write errors.
+ * 	       This means that the only acceptable arguments are pointers to
+ * 	       variable-length arrays, 1D std::vector of dimension mudim*mudim, or
+ * 	       1D raw(resp. std::array) arrays of dimension mudim*mudim.
+ * @param[in]  mudim - the number of rows(resp. columns) in the mu array.
+ * @param[out] mutranspose - when true, mutranspose is stored in the mu param.
+ *                           Otherwise, mu is stored in the mu param.
+ * 			Storing mutranspose allows for more efficient memory access, as accesses
+ * will be contiguous.
+ * @param[out] rdiag - a pointer to an array 'enumf rdiag[mudim]'.
+ * 	               Upon return, this will contain the squared norms of the Gram-Schmidt vectors.
+ * @param[out] pruning - a pointer to an array 'enumf pruning[mudim]'. Upon return, this will
+ * contain the pruning coefficients for enumeration. In rigorous enumeration, this array will
+ * consist solely of 1's.
+ */
+typedef void(extenum_cb_set_config)(fplll_extenum_enumf *mu, std::size_t mudim, bool mutranspose, fplll_extenum_enumf *rdiag,
+                                    fplll_extenum_enumf *pruning);
+
+/**
+ * Callback function given to external enumeration library.
+ * Passes a new solution and its length to Evaluator, returning the new enumeration bound.
+ * @param[in] dist - the norm of the new solution.
+ * @param[in] sol - a pointer to the new solution.
+ * @return The new enumeration bound.
+ */
+typedef fplll_extenum_enumf(extenum_cb_process_sol)(fplll_extenum_enumf dist, fplll_extenum_enumf *sol);
+
+/**
+ * Callback function given to external enumeration library.
+ *
+ * Pass a subsolution and its partial length to Evaluator.
+ */
+typedef void(extenum_cb_process_subsol)(fplll_extenum_enumf dist, fplll_extenum_enumf *subsol, int offset);
+
+/**
+ * External enumeration function prototype.
+ *
+ * @param dim         enumeration dimension.
+ * @param maxdist     initial enumeration bound.
+ * @param cbfunc      given callback function to get mu, rdiag, pruning
+ * @param cbsol       given callback function to pass solution and its length to Evaluator,
+ *                    it returns new enumeration bound
+ * @param cbsubsol    given callback function to pass subsolution and its length to Evaluator
+ * @param dual        do dual SVP enumeration
+ * @param findsubsols find subsolutions and pass them to Evaluator
+ * @return number of nodes visited.
+ *         Or ~uint64_t(0) when instance is not supported
+ *         in which case fplll falls back to its own enumeration.
+ */
+typedef std::array<std::uint64_t, FPLLL_EXTENUM_MAX_EXTENUM_DIM>(extenum_fc_enumerate)(
+    const int dim, fplll_extenum_enumf maxdist, std::function<extenum_cb_set_config> cbfunc,
+    std::function<extenum_cb_process_sol> cbsol, std::function<extenum_cb_process_subsol> cbsubsol,
+    bool dual /*=false*/, bool findsubsols /*=false*/
+);
+
+#endif

--- a/fplll/enum/enumerate_ext_api.h
+++ b/fplll/enum/enumerate_ext_api.h
@@ -48,8 +48,8 @@ typedef double fplll_extenum_enumf;
  * contain the pruning coefficients for enumeration. In rigorous enumeration, this array will
  * consist solely of 1's.
  */
-typedef void(extenum_cb_set_config)(fplll_extenum_enumf *mu, std::size_t mudim, bool mutranspose, fplll_extenum_enumf *rdiag,
-                                    fplll_extenum_enumf *pruning);
+typedef void(extenum_cb_set_config)(fplll_extenum_enumf *mu, std::size_t mudim, bool mutranspose,
+                                    fplll_extenum_enumf *rdiag, fplll_extenum_enumf *pruning);
 
 /**
  * Callback function given to external enumeration library.
@@ -58,14 +58,16 @@ typedef void(extenum_cb_set_config)(fplll_extenum_enumf *mu, std::size_t mudim, 
  * @param[in] sol - a pointer to the new solution.
  * @return The new enumeration bound.
  */
-typedef fplll_extenum_enumf(extenum_cb_process_sol)(fplll_extenum_enumf dist, fplll_extenum_enumf *sol);
+typedef fplll_extenum_enumf(extenum_cb_process_sol)(fplll_extenum_enumf dist,
+                                                    fplll_extenum_enumf *sol);
 
 /**
  * Callback function given to external enumeration library.
  *
  * Pass a subsolution and its partial length to Evaluator.
  */
-typedef void(extenum_cb_process_subsol)(fplll_extenum_enumf dist, fplll_extenum_enumf *subsol, int offset);
+typedef void(extenum_cb_process_subsol)(fplll_extenum_enumf dist, fplll_extenum_enumf *subsol,
+                                        int offset);
 
 /**
  * External enumeration function prototype.

--- a/fplll/fplll_config.h.in
+++ b/fplll/fplll_config.h.in
@@ -35,4 +35,7 @@
 #undef HAVE_LIBGMP
 #undef HAVE_LIBMPIR
 
+/* external enumeration */
+#undef FPLLL_EXTENUM_FUNC
+
 #endif //FPLLL_CONFIG__H


### PR DESCRIPTION
This PR makes it possible to directly integrate any external enumeration into fplll and be used by default by fplll.