### PR TITLE
Fix #474 -- remove redundant template parameters

### DIFF
--- a/fplll/gso_interface.h
+++ b/fplll/gso_interface.h
@@ -71,11 +71,11 @@ public:
    *   (in this case both must have the same number of rows).
    *   If u is initially the identity matrix, multiplying transform by the
    *   initial basis gives the current basis.
-   *   In other words, u will contain the transformation matrix used on the basis b 
+   *   In other words, u will contain the transformation matrix used on the basis b
    *   that was used to obtain the current basis.
    * @param u_inv_t
    *   Inverse transform (should be empty, which disables the computation, or
-   *   initialized with identity matrix). It works only if u is not empty. 
+   *   initialized with identity matrix). It works only if u is not empty.
    * @param enable_int_gram
    *   If true, coefficients of the Gram matrix are computed with exact integer
    *   arithmetic (type ZT). Otherwise, they are computed in floating-point

--- a/fplll/gso_interface.h
+++ b/fplll/gso_interface.h
@@ -71,9 +71,11 @@ public:
    *   (in this case both must have the same number of rows).
    *   If u is initially the identity matrix, multiplying transform by the
    *   initial basis gives the current basis.
+   *   In other words, u will contain the transformation matrix used on the basis b 
+   *   that was used to obtain the current basis.
    * @param u_inv_t
    *   Inverse transform (should be empty, which disables the computation, or
-   *   initialized with identity matrix). It works only if u is not empty.
+   *   initialized with identity matrix). It works only if u is not empty. 
    * @param enable_int_gram
    *   If true, coefficients of the Gram matrix are computed with exact integer
    *   arithmetic (type ZT). Otherwise, they are computed in floating-point

--- a/fplll/nr/nr_FP.inl
+++ b/fplll/nr/nr_FP.inl
@@ -29,7 +29,7 @@ public:
    */
   inline FP_NR<F>();
   inline FP_NR<F>(const FP_NR<F> &f);
-  inline ~FP_NR<F>();
+  inline ~FP_NR();
   inline FP_NR<F>(const double d) : FP_NR<F>() { *this = d; };
   inline FP_NR<F>(const char *s) : FP_NR<F>() { *this = s; };
 

--- a/fplll/nr/nr_Z.inl
+++ b/fplll/nr/nr_Z.inl
@@ -24,10 +24,10 @@ public:
   /**
    * Constructors.
    */
-  inline Z_NR<Z>();
-  inline Z_NR<Z>(const Z_NR<Z> &z);
-  inline Z_NR<Z>(const Z &z);
-  inline ~Z_NR<Z>();
+  inline Z_NR();
+  inline Z_NR(const Z_NR<Z> &z);
+  inline Z_NR(const Z &z);
+  inline ~Z_NR();
 
   /** get data */
 

--- a/fplll/wrapper.h
+++ b/fplll/wrapper.h
@@ -32,11 +32,17 @@ FPLLL_BEGIN_NAMESPACE
  * heuristic and fast variants of both LLL and HLLL.
  *
  * User note: all of the parameters passed into this class are non-const references. Thus, this
- * class may overwrite these variables. In particular, the methods in this class typically
+ * class may overwrite these variables. 
+ *
+ * In particular, the methods in this class typically
  * over-write the parameter ``u`` with the transformation matrix applied to ``b`` to produce LLL(B).
  * In other words, let C = LLL(B). Then we can write C = U B for some unimodular transformation
  * matrix U. For this reason, ``u`` should either be an empty matrix or the identity matrix when it
- * is passed in to this function, so that no information is lost.
+ * is passed in to this function, so that no information is lost. 
+ *
+ * Similarly, the parameter ``u_inv`` will contain the inverse matrix ``u ^ -1``. 
+ * This allows you to recover the original basis ``b`` by multipyling ``C`` by ``u_inv``.
+ * This and other such behaviour on these parameters is described in some detail in gso_interface.h. 
  */
 class Wrapper
 {

--- a/fplll/wrapper.h
+++ b/fplll/wrapper.h
@@ -25,10 +25,24 @@ FPLLL_BEGIN_NAMESPACE
 /* The matrix b must not be modified before calling lll().
    lll() must be called only once. */
 
+
+/**
+ * @brief Wrapper. This class provides an externally callable API for LLL reducing some basis ``b``.
+ * This class forcibly instantiates some template declarations (see FPLLL_DECLARE_LLL(T) for more
+ * information at the bottom of this class) and provides an interface for calling provable, heuristic
+ * and fast variants of both LLL and HLLL.
+ *
+ * User note: all of the parameters passed into this class are non-const references. Thus, this class
+ * may overwrite these variables. In particular, the methods in this class typically over-write 
+ * the parameter ``u`` with the transformation matrix applied to ``b`` to produce LLL(B). 
+ * In other words, let C = LLL(B). Then we can write C = U^T B for some unimodular transformation
+ * matrix U. For this reason, ``u`` should either be an empty matrix or the identity matrix when it 
+ * is passed in to this function, so that no information is lost.  
+ */
 class Wrapper
 {
 public:
-  /* u must be either empty or the identity matrix */
+  /* u must be either empty of the identity matrix */
   Wrapper(ZZ_mat<mpz_t> &b, ZZ_mat<mpz_t> &u, ZZ_mat<mpz_t> &u_inv, double delta, double eta,
           int flags);
 

--- a/fplll/wrapper.h
+++ b/fplll/wrapper.h
@@ -34,7 +34,7 @@ FPLLL_BEGIN_NAMESPACE
  * User note: all of the parameters passed into this class are non-const references. Thus, this
  * class may overwrite these variables. In particular, the methods in this class typically
  * over-write the parameter ``u`` with the transformation matrix applied to ``b`` to produce LLL(B).
- * In other words, let C = LLL(B). Then we can write C = U^T B for some unimodular transformation
+ * In other words, let C = LLL(B). Then we can write C = U B for some unimodular transformation
  * matrix U. For this reason, ``u`` should either be an empty matrix or the identity matrix when it
  * is passed in to this function, so that no information is lost.
  */

--- a/fplll/wrapper.h
+++ b/fplll/wrapper.h
@@ -25,19 +25,18 @@ FPLLL_BEGIN_NAMESPACE
 /* The matrix b must not be modified before calling lll().
    lll() must be called only once. */
 
-
 /**
  * @brief Wrapper. This class provides an externally callable API for LLL reducing some basis ``b``.
  * This class forcibly instantiates some template declarations (see FPLLL_DECLARE_LLL(T) for more
- * information at the bottom of this class) and provides an interface for calling provable, heuristic
- * and fast variants of both LLL and HLLL.
+ * information at the bottom of this class) and provides an interface for calling provable,
+ * heuristic and fast variants of both LLL and HLLL.
  *
- * User note: all of the parameters passed into this class are non-const references. Thus, this class
- * may overwrite these variables. In particular, the methods in this class typically over-write 
- * the parameter ``u`` with the transformation matrix applied to ``b`` to produce LLL(B). 
+ * User note: all of the parameters passed into this class are non-const references. Thus, this
+ * class may overwrite these variables. In particular, the methods in this class typically
+ * over-write the parameter ``u`` with the transformation matrix applied to ``b`` to produce LLL(B).
  * In other words, let C = LLL(B). Then we can write C = U^T B for some unimodular transformation
- * matrix U. For this reason, ``u`` should either be an empty matrix or the identity matrix when it 
- * is passed in to this function, so that no information is lost.  
+ * matrix U. For this reason, ``u`` should either be an empty matrix or the identity matrix when it
+ * is passed in to this function, so that no information is lost.
  */
 class Wrapper
 {

--- a/fplll/wrapper.h
+++ b/fplll/wrapper.h
@@ -32,17 +32,17 @@ FPLLL_BEGIN_NAMESPACE
  * heuristic and fast variants of both LLL and HLLL.
  *
  * User note: all of the parameters passed into this class are non-const references. Thus, this
- * class may overwrite these variables. 
+ * class may overwrite these variables.
  *
  * In particular, the methods in this class typically
  * over-write the parameter ``u`` with the transformation matrix applied to ``b`` to produce LLL(B).
  * In other words, let C = LLL(B). Then we can write C = U B for some unimodular transformation
  * matrix U. For this reason, ``u`` should either be an empty matrix or the identity matrix when it
- * is passed in to this function, so that no information is lost. 
+ * is passed in to this function, so that no information is lost.
  *
- * Similarly, the parameter ``u_inv`` will contain the inverse matrix ``u ^ -1``. 
+ * Similarly, the parameter ``u_inv`` will contain the inverse matrix ``u ^ -1``.
  * This allows you to recover the original basis ``b`` by multipyling ``C`` by ``u_inv``.
- * This and other such behaviour on these parameters is described in some detail in gso_interface.h. 
+ * This and other such behaviour on these parameters is described in some detail in gso_interface.h.
  */
 class Wrapper
 {

--- a/fplll/wrapper.h
+++ b/fplll/wrapper.h
@@ -41,7 +41,10 @@ FPLLL_BEGIN_NAMESPACE
  * is passed in to this function, so that no information is lost.
  *
  * Similarly, the parameter ``u_inv`` will contain the inverse matrix ``u ^ -1``.
- * This allows you to recover the original basis ``b`` by multipyling ``C`` by ``u_inv``.
+ * This allows you to recover the original basis ``b`` by multiplying ``C`` by ``u_inv``.
+ * Note that all operations on this object are carried out on the transpose of this matrix 
+ * (see gso_interface.h) for speed: hence the discrepancy between the names (see the lll_reduction method
+ * in wraper.cpp for this). 
  * This and other such behaviour on these parameters is described in some detail in gso_interface.h.
  */
 class Wrapper

--- a/fplll/wrapper.h
+++ b/fplll/wrapper.h
@@ -41,7 +41,7 @@ FPLLL_BEGIN_NAMESPACE
 class Wrapper
 {
 public:
-  /* u must be either empty of the identity matrix */
+  /* u must be either empty or the identity matrix */
   Wrapper(ZZ_mat<mpz_t> &b, ZZ_mat<mpz_t> &u, ZZ_mat<mpz_t> &u_inv, double delta, double eta,
           int flags);
 

--- a/fplll/wrapper.h
+++ b/fplll/wrapper.h
@@ -42,10 +42,10 @@ FPLLL_BEGIN_NAMESPACE
  *
  * Similarly, the parameter ``u_inv`` will contain the inverse matrix ``u ^ -1``.
  * This allows you to recover the original basis ``b`` by multiplying ``C`` by ``u_inv``.
- * Note that all operations on this object are carried out on the transpose of this matrix 
- * (see gso_interface.h) for speed: hence the discrepancy between the names (see the lll_reduction method
- * in wraper.cpp for this). 
- * This and other such behaviour on these parameters is described in some detail in gso_interface.h.
+ * Note that all operations on this object are carried out on the transpose of this matrix
+ * (see gso_interface.h) for speed: hence the discrepancy between the names (see the lll_reduction
+ * method in wraper.cpp for this). This and other such behaviour on these parameters is described in
+ * some detail in gso_interface.h.
  */
 class Wrapper
 {


### PR DESCRIPTION
# What's the problem?

C++20 appears to have outlawed something that fplll had before: redundant typenames in destructors. In particular, the following isn't legal anymore:

```
template<typename F>
class F_Wrapper {
      ~F_Wrapper<F>();
};
```

The standard justifies this as fixing the defects identified in [CWG2237](http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#2237)

# What's the fix?
Just remove the template parameters; they weren't ever necessary.

