### PR TITLE
Remove 'using namespace fplll' (fix #447)

### DIFF
--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -124,7 +124,6 @@ libfpllld_la_LDFLAGS=$(libfplll_la_LDFLAGS)
 
 install-data-hook:
 	echo "#include <fplll/fplll.h>" > "$(builddir)/fplll.h.root"
-	echo "using namespace fplll;" >> "$(builddir)/fplll.h.root"
 	$(INSTALL) -m 644 "$(builddir)/fplll.h.root" "${DESTDIR}$(includedir)/fplll.h"
 	rm -f "$(builddir)/fplll.h.root"
 


### PR DESCRIPTION
This PR just removes the "using namespace fplll" line from  ```fplll/Makefile.am ``` due to the ticket #477.

Compulation, installation and make check all work locally. I also tested this by pre-processing the following test file:

```
#include<iostream>
#include<fplll.h>

int main() {
    ZZ_mat<mpz_t> mat;
    std::cin >> mat;
    std::cout << mat ;
   return 0;
}

```
Running ```gcc -E``` on this gives the following (explicitly shortened):

```
} 
# 34 "/usr/local/include/fplll/fplll.h" 2 3
# 1 "/usr/local/include/fplll.h" 2 3
# 3 "test.cpp" 2
```

In other words, the ```using namespace fplll``` is no longer present.
