### PR TITLE
Fix for #479 - replace static mpfr with temporaries

### DIFF
--- a/fplll/lll.h
+++ b/fplll/lll.h
@@ -36,7 +36,9 @@ public:
    * needed).
    */
   LLLReduction(MatGSOInterface<ZT, FT> &m, double delta, double eta, int flags);
-
+#ifdef FPLLL_WITH_LONG_DOUBLE
+  ~LLLReduction() { LDConvHelper::free(); }
+#endif
   /**
      @brief LLL reduction.
 

--- a/fplll/lll.h
+++ b/fplll/lll.h
@@ -37,10 +37,6 @@ public:
    */
   LLLReduction(MatGSOInterface<ZT, FT> &m, double delta, double eta, int flags);
 
-#ifdef FPLLL_WITH_LONG_DOUBLE
-  ~LLLReduction() { LDConvHelper::free(); }
-#endif
-
   /**
      @brief LLL reduction.
 

--- a/fplll/nr/nr_Z.inl
+++ b/fplll/nr/nr_Z.inl
@@ -240,7 +240,7 @@ public:
 // These are global to replace their previous usage, but member variables
 // cannot be thread local and so they're declared at this scope.
 // NOTE: these are extern because these can only have one definition.
-// These are declared in util.cpp
+// These are defined in util.cpp
 extern thread_local mpfr_t temp_mpfr;
 extern thread_local bool temp_mpfr_initialized;
 

--- a/fplll/nr/nr_Z.inl
+++ b/fplll/nr/nr_Z.inl
@@ -242,12 +242,13 @@ public:
   /** Converts op to a long double with rounding to nearest. */
   static long double mpz_get_ld(const mpz_t op)
   {
-    init_temp();
+    mpfr_t temp;
+    mpfr_init2(temp, numeric_limits<long double>::digits);
     mpfr_set_z(temp, op, GMP_RNDN);
-    return mpfr_get_ld(temp, GMP_RNDN);  // exact
+    const auto result{mpfr_get_ld(temp, GMP_RNDN)};  // exact
+    mpfr_clear(temp);
+    return result;
   }
-
-  static void free() { free_temp(); }
 
   /**
    * Returns d and sets exp such that 0.5 <= |d| < 1 and d * 2^exp is equal
@@ -255,41 +256,24 @@ public:
    */
   static long double mpz_get_ld_2exp(long *exp, const mpz_t op)
   {
-    init_temp();
+    mpfr_t temp;
+    mpfr_init2(temp, numeric_limits<long double>::digits);
     mpfr_set_z(temp, op, GMP_RNDN);
-    return mpfr_get_ld_2exp(exp, temp, GMP_RNDN);  // exact
+
+    const auto result{mpfr_get_ld_2exp(exp, temp, GMP_RNDN)};  // exact
+    mpfr_clear(temp);
+    return result;
   }
 
   /** Sets the value of rop from op. */
   static void mpz_set_ld(mpz_t rop, long double op)
   {
-    init_temp();
+    mpfr_t temp;
+    mpfr_init2(temp, numeric_limits<long double>::digits);
     mpfr_set_ld(temp, op, GMP_RNDN);  // exact
     mpfr_get_z(rop, temp, GMP_RNDN);
+    mpfr_clear(temp);
   }
-
-private:
-  static inline void init_temp()
-  {
-    if (!temp_initialized)
-    {
-      mpfr_init2(temp, numeric_limits<long double>::digits);
-      temp_initialized = true;
-    }
-  }
-
-  static inline void free_temp()
-  {
-    if (temp_initialized)
-    {
-      mpfr_clear(temp);
-      temp_initialized = false;
-    }
-  }
-
-  // These static members are initialized in util.cpp
-  static mpfr_t temp;
-  static bool temp_initialized;
 };
 
 #endif

--- a/fplll/util.cpp
+++ b/fplll/util.cpp
@@ -27,13 +27,6 @@ enum MinPrecAlgo
   MINPREC_L2
 };
 
-/* State of LDConvHelper (declared in nr.h, must be defined in exactly one
-   source file) */
-#ifdef FPLLL_WITH_LONG_DOUBLE
-mpfr_t LDConvHelper::temp;
-bool LDConvHelper::temp_initialized = false;
-#endif
-
 /* State of the random generator (declared in nr.h, must be defined in exactly
    one source file) */
 bool RandGen::initialized = false;

--- a/fplll/util.cpp
+++ b/fplll/util.cpp
@@ -27,6 +27,15 @@ enum MinPrecAlgo
   MINPREC_L2
 };
 
+/*
+  Helper variables for LDConvHelper (declared in nr_Z.inl, must be defined in exactly
+  one source file)
+*/
+#ifdef FPLLL_WITH_LONG_DOUBLE
+thread_local mpfr_t temp_mpfr;
+thread_local bool temp_mpfr_initialized{false};
+#endif
+
 /* State of the random generator (declared in nr.h, must be defined in exactly
    one source file) */
 bool RandGen::initialized = false;


### PR DESCRIPTION
This PR fixes #479 by replacing the statically instance of ```mpfr_t``` with a temporary on each call to the functions in ```LDConvHelper```. This is a definite performance regression, but I have no idea if these functions are used much.  