### PR TITLE
Add full strategy path (c.f #485)

### DIFF
--- a/fplll/bkz_param.cpp
+++ b/fplll/bkz_param.cpp
@@ -81,7 +81,7 @@ vector<Strategy> load_strategies_json(const std::string &filename)
 {
   json js;
   {
-    std::ifstream fs(filename);
+    std::ifstream fs(strategy_full_path(filename));
     if (fs.fail())
       throw std::runtime_error("Cannot open strategies file.");
     fs >> js;


### PR DESCRIPTION
This just adds the ```full_strategy_path``` to ```load_strategies_json```. This doesn't make any changes to the file path if it isn't fully qualified, so the original behaviour should be preserved. This should address #485 and https://github.com/fplll/fpylll/issues/221.  