### PR TITLE
Make getters for rows and cols constant for the GSO.

### DIFF
--- a/fplll/gso.h
+++ b/fplll/gso.h
@@ -142,8 +142,8 @@ public:
 
   virtual inline long get_max_exp_of_b();
   virtual inline bool b_row_is_zero(int i);
-  virtual inline int get_cols_of_b();
-  virtual inline int get_rows_of_b();
+  virtual inline int get_cols_of_b() const;
+  virtual inline int get_rows_of_b() const;
   virtual inline void negate_row_of_b(int i);
 
   virtual inline void create_rows(int n_new_rows);
@@ -230,9 +230,15 @@ template <class ZT, class FT> inline bool MatGSO<ZT, FT>::b_row_is_zero(int i)
 {
   return b[i].is_zero();
 }
-template <class ZT, class FT> inline int MatGSO<ZT, FT>::get_cols_of_b() { return b.get_cols(); }
+template <class ZT, class FT> inline int MatGSO<ZT, FT>::get_cols_of_b() const
+{
+  return b.get_cols();
+}
 
-template <class ZT, class FT> inline int MatGSO<ZT, FT>::get_rows_of_b() { return b.get_rows(); }
+template <class ZT, class FT> inline int MatGSO<ZT, FT>::get_rows_of_b() const
+{
+  return b.get_rows();
+}
 
 template <class ZT, class FT> inline void MatGSO<ZT, FT>::negate_row_of_b(int i)
 {

--- a/fplll/gso_gram.h
+++ b/fplll/gso_gram.h
@@ -94,8 +94,8 @@ public:
 public:
   virtual inline long get_max_exp_of_b();
   virtual inline bool b_row_is_zero(int i);
-  virtual inline int get_cols_of_b();
-  virtual inline int get_rows_of_b();
+  virtual inline int get_cols_of_b() const;
+  virtual inline int get_rows_of_b() const;
   virtual inline void negate_row_of_b(int i);
 
   //  inline void set_g(Matrix<ZT> arg_g)
@@ -192,7 +192,7 @@ template <class ZT, class FT> inline bool MatGSOGram<ZT, FT>::b_row_is_zero(int 
   // now, we just check whether g[i][i] is zero.
   return g[i][i].is_zero();
 }
-template <class ZT, class FT> inline int MatGSOGram<ZT, FT>::get_cols_of_b()
+template <class ZT, class FT> inline int MatGSOGram<ZT, FT>::get_cols_of_b() const
 {
   if (gptr == nullptr)
   {
@@ -204,7 +204,7 @@ template <class ZT, class FT> inline int MatGSOGram<ZT, FT>::get_cols_of_b()
   return gptr->get_cols();
 }
 
-template <class ZT, class FT> inline int MatGSOGram<ZT, FT>::get_rows_of_b()
+template <class ZT, class FT> inline int MatGSOGram<ZT, FT>::get_rows_of_b() const
 {
   if (gptr == nullptr)
   {

--- a/fplll/gso_interface.h
+++ b/fplll/gso_interface.h
@@ -146,14 +146,14 @@ public:
    *  the gram version it returns the number
    *  of columns of g.
    */
-  virtual int get_cols_of_b() = 0;
+  virtual int get_cols_of_b() const = 0;
 
   /** Returns number of rows of b. In
    * the gram version it returns the number
    * of of rows of g. This function is made
    * to reduce code repetition (dump_mu/dump_r)
    */
-  virtual int get_rows_of_b() = 0;
+  virtual int get_rows_of_b() const = 0;
 
   /** Negates the ith row of b. Needed
    * by dbkz_postprocessing.


### PR DESCRIPTION
At the moment we can't write:

```
template<typename ZT, typename FT>
void do_thing(const MatGSOInterface<ZT, FT>& gso) {
    const auto rows = gso.get_rows_of_b();
    ...
}
```

Because the getters aren't marked as ```const```.  They should be -- both conceptually (we wouldn't expect this to change the underlying object), and in practice, since ```Matrix``` marks these functions as ```const```:

https://github.com/fplll/fplll/blob/9f780667b318edf28b53a778ecd9f06b2c0b8fcf/fplll/nr/matrix.h#L153-L154

This PR just makes those getters (e.g ```get_rows_of_b``` and ```get_cols_of_b```) ```const```. 