### PR TITLE
Add support for ceiling floating point numbers.

### DIFF
--- a/fplll/nr/nr_FP.inl
+++ b/fplll/nr/nr_FP.inl
@@ -350,6 +350,11 @@ public:
   inline void floor(const FP_NR<F> &b);
 
   /**
+   * value := smallest integer greater than (or equal to) b.
+   **/
+  inline void ceil(const FP_NR<F> &b);
+
+  /**
    * value := NaN.
    */
   inline void set_nan();

--- a/fplll/nr/nr_FP_d.inl
+++ b/fplll/nr/nr_FP_d.inl
@@ -234,6 +234,8 @@ template <> inline void FP_NR<double>::rnd_we(const FP_NR<double> &b, long expo_
 
 template <> inline void FP_NR<double>::floor(const FP_NR<double> &b) { data = ::floor(b.data); }
 
+template <> inline void FP_NR<double>::ceil(const FP_NR<double> &b) { data = ::ceil(b.data); }
+
 template <> inline void FP_NR<double>::set_nan() { data = NAN; }
 
 template <> inline void FP_NR<double>::swap(FP_NR<double> &a) { std::swap(data, a.data); }

--- a/fplll/nr/nr_FP_dd.inl
+++ b/fplll/nr/nr_FP_dd.inl
@@ -242,6 +242,8 @@ template <> inline void FP_NR<dd_real>::rnd_we(const FP_NR<dd_real> &b, long exp
 
 template <> inline void FP_NR<dd_real>::floor(const FP_NR<dd_real> &b) { data = ::floor(b.data); }
 
+template <> inline void FP_NR<dd_real>::ceil(const FP_NR<dd_real> &b) { data = ::ceil(b.data); }
+
 template <> inline void FP_NR<dd_real>::set_nan() { data = NAN; }
 
 template <> inline void FP_NR<dd_real>::swap(FP_NR<dd_real> &a)

--- a/fplll/nr/nr_FP_dpe.inl
+++ b/fplll/nr/nr_FP_dpe.inl
@@ -219,6 +219,8 @@ template <> inline void FP_NR<dpe_t>::rnd_we(const FP_NR<dpe_t> &a, long /*expo_
 
 template <> inline void FP_NR<dpe_t>::floor(const FP_NR<dpe_t> &a) { dpe_floor(data, a.data); }
 
+template <> inline void FP_NR<dpe_t>::ceil(const FP_NR<dpe_t> &a) { dpe_ceil(data, a.data); }
+
 template <> inline void FP_NR<dpe_t>::set_nan()
 {
   // dpe_set_d(data, NAN); // DPE_UNLIKELY branch in dpe_normalize

--- a/fplll/nr/nr_FP_ld.inl
+++ b/fplll/nr/nr_FP_ld.inl
@@ -258,6 +258,11 @@ template <> inline void FP_NR<long double>::floor(const FP_NR<long double> &b)
   data = floorl(b.data);
 }
 
+template <> inline void FP_NR<long double>::ceil(const FP_NR<long double> &b)
+{
+  data = ceill(b.data);
+}
+
 template <> inline void FP_NR<long double>::set_nan() { data = NAN; }
 
 template <> inline void FP_NR<long double>::swap(FP_NR<long double> &a) { std::swap(data, a.data); }

--- a/fplll/nr/nr_FP_mpfr.inl
+++ b/fplll/nr/nr_FP_mpfr.inl
@@ -243,6 +243,8 @@ template <> inline void FP_NR<mpfr_t>::rnd_we(const FP_NR<mpfr_t> &a, long /*exp
 }
 template <> inline void FP_NR<mpfr_t>::floor(const FP_NR<mpfr_t> &a) { mpfr_floor(data, a.data); }
 
+template <> inline void FP_NR<mpfr_t>::ceil(const FP_NR<mpfr_t> &a) { mpfr_ceil(data, a.data); }
+
 template <> inline void FP_NR<mpfr_t>::set_nan() { mpfr_set_nan(data); }
 
 template <> inline void FP_NR<mpfr_t>::swap(FP_NR<mpfr_t> &a) { mpfr_swap(data, a.data); }

--- a/fplll/nr/nr_FP_qd.inl
+++ b/fplll/nr/nr_FP_qd.inl
@@ -238,6 +238,8 @@ template <> inline void FP_NR<qd_real>::rnd_we(const FP_NR<qd_real> &b, long exp
 
 template <> inline void FP_NR<qd_real>::floor(const FP_NR<qd_real> &b) { data = ::floor(b.data); }
 
+template <> inline void FP_NR<qd_real>::ceil(const FP_NR<qd_real> &b) { data = ::ceil(b.data); }
+
 template <> inline void FP_NR<qd_real>::set_nan() { data = NAN; }
 
 template <> inline void FP_NR<qd_real>::swap(FP_NR<qd_real> &a)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,7 +43,7 @@ AM_CPPFLAGS = -I$(TOPSRCDIR) -I$(TOPSRCDIR)/fplll -I$(TOPBUILDDIR) -DTESTDATADIR
 STAGEDIR := $(realpath -s $(TOPBUILDDIR)/.libs)
 AM_LDFLAGS = -L$(STAGEDIR) -Wl,-rpath,$(STAGEDIR) -lfplll -no-install $(LIBQD_LIBS)
 
-TESTS = test_nr test_lll test_enum test_cvp test_svp test_bkz test_pruner test_gso test_lll_gram test_hlll test_svp_gram test_bkz_gram test_counter test_babai
+TESTS = test_nr test_lll test_enum test_cvp test_svp test_bkz test_pruner test_gso test_lll_gram test_hlll test_svp_gram test_bkz_gram test_counter test_babai test_ceil
 
 test_pruner_LDADD=$(LIBQD_LIBS)
 
@@ -61,4 +61,5 @@ test_svp_gram_SOURCES = test_svp_gram.cpp
 test_bkz_gram_SOURCES = test_bkz_gram.cpp
 test_counter_SOURCES  = test_counter.cpp
 test_babai_SOURCES  = test_babai.cpp
+test_ceil_SOURCES = test_ceil.cpp
 check_PROGRAMS = $(TESTS)

--- a/tests/test_ceil.cpp
+++ b/tests/test_ceil.cpp
@@ -1,0 +1,52 @@
+#include "fplll/fplll.h"
+
+using namespace fplll;
+
+template <class T> bool test_ceil()
+{
+
+  bool status = false;
+
+  // Case 1: works with fixed values.
+  FP_NR<T> value(3.5);
+  FP_NR<T> ceiled{};
+  ceiled.ceil(value);
+
+  status |= (ceiled != 4);
+
+  // Case 2: calling ceil either gives us a number >= value.
+  value = rand();
+  ceiled.ceil(value);
+  status |= (ceiled < value);
+  return status;
+}
+
+int main(int, char **)
+{
+  int status = 0;
+  status += test_ceil<mpfr_t>();
+  status += test_ceil<double>();
+#ifdef FPLLL_WITH_LONG_DOUBLE
+  status += test_ceil<long double>();
+#endif
+
+#ifdef FPLLL_WITH_QD
+  status += test_ceil<dd_real>();
+  status += test_ceil<qd_real>();
+#endif
+
+#ifdef FPLLL_WITH_DPE
+  status += test_ceil<dpe_t>();
+#endif
+
+  if (status == 0)
+  {
+    std::cerr << "All tests passed" << std::endl;
+    return 0;
+  }
+  else
+  {
+    return -1;
+  }
+  return 0;
+}


### PR DESCRIPTION
At the moment fplll supports flooring and rounding ```FP_NR<F>```, but not ceiling. This PR just adds support for ceiling ```FP_NR<F>```. 