### PR TITLE
Compute denominator directly in slope calculation

### DIFF
--- a/fplll/gso_interface.h
+++ b/fplll/gso_interface.h
@@ -409,8 +409,11 @@ public:
   inline void dump_r_d(vector<double> &r, int offset = 0, int block_size = -1);
 
   /**
-     @brief Return slope of the curve fitted to the lengths of the vectors from
+     @brief Return slope of the line fitted to the lengths of the vectors from
      `start_row` to `stop_row`.
+
+     The line is found with the method of least squares and minimizes the sum
+     of squared errors.
 
      The slope gives an indication of the quality of the basis.
 


### PR DESCRIPTION
This provides a (hopefully) small speed up to calculation of the current slope, although this is probably negligible in the bigger picture.

- Remove any memory usage in the vector x as we can compute the numerator directly.
- The denominator is now calculated with: $$\sum^{n-1}_{i=0} \left(i - \frac{n-1}{2} \right)^2 = \frac{(n+1)n(n-1)}{12}.$$
- Change the documentation to say that the curve is a line fitted with least squares method.