### PR TITLE
Fix failing babai test.

### DIFF
--- a/tests/test_babai.cpp
+++ b/tests/test_babai.cpp
@@ -68,8 +68,9 @@ int test_intrel(long n, long bits, bool shouldfail = false, int seed = 0)
   }
   else
   {
-    std::cerr << "n:" << n << ", bits: " << bits << std::endl;
-    std::cerr << w << std::endl;
+    std::cerr << "n:" << n << ", bits: " << bits << ", shouldfail:" << shouldfail << std::endl;
+    std::cerr << "t:" << t << std::endl;
+    std::cerr << "w:" << w << std::endl;
     return 1;
   }
 }
@@ -83,8 +84,13 @@ int main(int argc, char *argv[])
   status += test_intrel<mpz_t, double>(10, 40);
   status += test_intrel<mpz_t, double>(10, 50);
   status += test_intrel<mpz_t, double>(10, 60, true);
-  status += test_intrel<mpz_t, long double>(10, 60);
+
 #ifdef FPLLL_WITH_LONG_DOUBLE
+  // Some platforms have sizeof(double) == sizeof(long double)
+  // because long double is only required to be at least as large
+  // as a double. This means the behaviour of the first test
+  // depends on the platform.
+  status += test_intrel<mpz_t, long double>(10, 60, sizeof(double) == sizeof(long double));
   status += test_intrel<mpz_t, long double>(10, 70, true);
 #endif
 #ifdef FPLLL_WITH_QD


### PR DESCRIPTION
TL;DR: ```long double``` isn't always 80 bits in length.

The old tests implicitly assumed that ```long double``` was more precise than ```double```:

https://github.com/fplll/fplll/blob/322b0a1c7db191a134ab3f7ab8af4597471b0af8/tests/test_babai.cpp#L86-L88

[However, this isn't true on all platforms](https://en.wikipedia.org/wiki/Long_double). Indeed, on my M1 Mac, both ```long double``` and ```double``` are 64-bits. 

This PR makes the behaviour of the test conditional on this detail. I also added some more printing, because it's easier to tell why the test is failing with more info :) 

This should address #500. Maybe we should add other platforms to the CI too?