### PR TITLE
Make Babai test more robust for PPC etc.

### DIFF
--- a/tests/test_babai.cpp
+++ b/tests/test_babai.cpp
@@ -109,10 +109,16 @@ int main(int argc, char *argv[])
   status += test_intrel<mpz_t, long double>(10, 70, LDBL_MANT_DIG < 70);
 #endif
 #ifdef FPLLL_WITH_QD
+  // QD needs to have the round-to-double flag set on x86 systems. This function
+  // does nothing on non-x86 machines (see the readme for the QD library for more).
+  // This is also already done in the wrapper.
+  unsigned old_cw;
+  fpu_fix_start(&old_cw);
   status += test_intrel<mpz_t, dd_real>(10, 110);
   status += test_intrel<mpz_t, dd_real>(10, 120, true);
   // status += test_intrel<mpz_t, qd_real>(10, 100);
   // status += test_intrel<mpz_t, qd_real>(10, 230, true);
+  fpu_fix_end(&old_cw);
 #endif
   FP_NR<mpfr_t>::set_prec(100);
   status += test_intrel<mpz_t, mpfr_t>(10, 100);

--- a/tests/test_babai.cpp
+++ b/tests/test_babai.cpp
@@ -16,7 +16,7 @@
 #include "fplll/fplll.h"
 #include <vector>
 
-#include<cfloat> // Needed for precision macros. 
+#include <cfloat>  // Needed for precision macros.
 
 using namespace fplll;
 
@@ -100,7 +100,7 @@ int main(int argc, char *argv[])
   // (3) On x86-64, some compilers may treat long double as the 80-bit extended precision
   //     x87 type. This means that there's more precision than a regular double. In this situation,
   //     the compiler may also make sizeof(long double) == 16, meaning that we cannot detect this
-  //     easily based on the size of long double alone. 
+  //     easily based on the size of long double alone.
   //
   // To circumvent these issues, we check how many elements are in the mantissa of long double,
   // using LDBL_MANT_DIG. Specifically, if LDBL_MANT_DIG == DBL_MANT_DIG, then we are in case (1).


### PR DESCRIPTION
Turns out I missed the case for ```long double``` being synonymous with ```__float128``` and a handful of other cases. This PR should finish #500. 