### PR TITLE
Remove FPLLL_SONUM from fplll/fplll_config.h.in

### DIFF
--- a/fplll/fplll_config.h.in
+++ b/fplll/fplll_config.h.in
@@ -13,9 +13,6 @@
 /* fplll micro version */
 #define FPLLL_MICRO_VERSION @FPLLL_MICRO_VERSION@
 
-/* fplll sonum */
-#define FPLLL_SONUM @FPLLL_SONUM@
-
 /* fplll version */
 #define FPLLL_VERSION @FPLLL_VERSION@
 


### PR DESCRIPTION
Nothing was ever substituted for the template `@FPLLL_SONUM@`, so the template was appearing verbatim in the generated `fplll/fplll_config.h`. Since that isn’t a usable value, we know that nobody was relying on this particular macro as part of the API.

Fixes #509.