### PR TITLE
std::result_of has been removed in C++20

### DIFF
--- a/fplll/io/thread_pool.hpp
+++ b/fplll/io/thread_pool.hpp
@@ -96,7 +96,7 @@ namespace thread_pool {
 
 		// enqueue a function and obtain a future on its return value
 		template<typename F, typename... Args>
-		auto enqueue(F&& f, Args&&... args) -> std::future<std::invoke_result_t<F, Args...>>;
+		auto enqueue(F&& f, Args&&... args) -> std::future<decltype(f(args...))>;
 
 		// push a trivial function without a future
 		void push(const std::function<void()>& f);
@@ -216,10 +216,10 @@ namespace thread_pool {
 	}
 
 	template<typename F, typename... Args>
-	inline auto thread_pool::enqueue(F&& f, Args&&... args)
-		-> std::future<std::invoke_result_t<F, Args...>>
+	inline auto thread_pool::enqueue(F&& f, Args&&... args) 
+		-> std::future<decltype(f(args ...))>
 	{
-		typedef typename std::invoke_result_t<F, Args...> return_type;
+		typedef decltype(f(args ...)) return_type;
 		auto task = std::make_shared< std::packaged_task<return_type()> >
 				( std::bind(std::forward<F>(f), std::forward<Args>(args)...) );
 		push( [task](){ (*task)(); } );

--- a/fplll/io/thread_pool.hpp
+++ b/fplll/io/thread_pool.hpp
@@ -96,7 +96,7 @@ namespace thread_pool {
 
 		// enqueue a function and obtain a future on its return value
 		template<typename F, typename... Args>
-		auto enqueue(F&& f, Args&&... args) -> std::future<typename std::result_of<F(Args...)>::type>;
+		auto enqueue(F&& f, Args&&... args) -> std::future<std::invoke_result_t<F, Args...>>;
 
 		// push a trivial function without a future
 		void push(const std::function<void()>& f);
@@ -216,10 +216,10 @@ namespace thread_pool {
 	}
 
 	template<typename F, typename... Args>
-	inline auto thread_pool::enqueue(F&& f, Args&&... args) 
-		-> std::future<typename std::result_of<F(Args...)>::type>
+	inline auto thread_pool::enqueue(F&& f, Args&&... args)
+		-> std::future<std::invoke_result_t<F, Args...>>
 	{
-		typedef typename std::result_of<F(Args...)>::type return_type;
+		typedef typename std::invoke_result_t<F, Args...> return_type;
 		auto task = std::make_shared< std::packaged_task<return_type()> >
 				( std::bind(std::forward<F>(f), std::forward<Args>(args)...) );
 		push( [task](){ (*task)(); } );

--- a/fplll/threadpool.h
+++ b/fplll/threadpool.h
@@ -51,7 +51,7 @@ typedef thread_pool::barrier barrier;
                 // advanced way to add job
                 template<typename F, typename... Args>
                 auto enqueue(F&& f, Args&&... args) -> std::future<typename
-   std::result_of<F(Args...)>::type>;
+                        std::invoke_result_t<F, Args...>>;
 
                 // process tasks with main thread & then wait until all threads are idle
                 // DO NOT CALL FROM A JOB FUNCTION: WILL CAUSE DEADLOCK


### PR DESCRIPTION
`std::result_of` has been deprecated in C++17, removed in C++20 and support has been removed from (some) recent compilers, in particular fplll 5.4.4 does not work with clang 16. This patch replaces `std::result_of` with uses of `decltype`.