### PR TITLE
disable long doubles on aarch64-darwin

### DIFF
--- a/fplll/defs.h
+++ b/fplll/defs.h
@@ -19,7 +19,7 @@
 #ifndef FPLLL_DEFS_H
 #define FPLLL_DEFS_H
 
-#ifndef __CYGWIN__
+#if !defined(__CYGWIN__) && !(defined(__APPLE__) && defined(__aarch64__))
 #define FPLLL_WITH_LONG_DOUBLE
 #endif
 


### PR DESCRIPTION
`aarch64-darwin` does not have support for long doubles; please see the corresponding [issue](https://github.com/fplll/fpylll/issues/269) and [fix](https://github.com/fplll/fpylll/pull/270) in `fpylll` for more information.