### PR TITLE
Unify header include style 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ stamp-h1
 /tests/test_sieve
 /tests/test_svp
 /tests/test_svp_gram
+**/*.DS_Store
+config.guess~
+config.sub~
+install-sh~

--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -7,9 +7,7 @@ EXTRA_DIST = io/json.hpp ballvol.const factorial.const
 
 CLEANFILES = *.gcov .libs/*.gcda .libs/*.gcno *.gcno *.gcda */*.gcno */*.gcda
 
-nodist_include_fplll_HEADERS=fplll_config.h
-
-nobase_include_fplll_HEADERS=defs.h fplll.h \
+nobase_include_fplll_HEADERS=defs.h fplll.h fplll_config.h \
 	nr/dpe.h \
 	nr/matrix.h \
 	nr/matrix.cpp \

--- a/fplll/enum/enumerate.h
+++ b/fplll/enum/enumerate.h
@@ -19,10 +19,10 @@
 #ifndef FPLLL_ENUMERATE_H
 #define FPLLL_ENUMERATE_H
 
+#include "../gso_interface.h"
 #include "enumerate_base.h"
 #include "enumerate_ext.h"
 #include "evaluator.h"
-#include "../gso_interface.h"
 #include <array>
 #include <memory>
 

--- a/fplll/enum/enumerate.h
+++ b/fplll/enum/enumerate.h
@@ -19,11 +19,11 @@
 #ifndef FPLLL_ENUMERATE_H
 #define FPLLL_ENUMERATE_H
 
+#include "enumerate_base.h"
+#include "enumerate_ext.h"
+#include "evaluator.h"
+#include "../gso_interface.h"
 #include <array>
-#include <fplll/enum/enumerate_base.h>
-#include <fplll/enum/enumerate_ext.h>
-#include <fplll/enum/evaluator.h>
-#include <fplll/gso_interface.h>
 #include <memory>
 
 FPLLL_BEGIN_NAMESPACE

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -19,9 +19,9 @@
 #ifndef FPLLL_ENUMERATE_BASE_H
 #define FPLLL_ENUMERATE_BASE_H
 
-#include "./enumerate_ext_api.h"
 #include "../fplll_config.h"
 #include "../nr/nr.h"
+#include "./enumerate_ext_api.h"
 #include <array>
 #include <cfenv>
 #include <cmath>

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -19,9 +19,9 @@
 #ifndef FPLLL_ENUMERATE_BASE_H
 #define FPLLL_ENUMERATE_BASE_H
 
-#include "fplll/enum/enumerate_ext_api.h"
-#include "fplll/fplll_config.h"
-#include "fplll/nr/nr.h"
+#include "./enumerate_ext_api.h"
+#include "../fplll_config.h"
+#include "../nr/nr.h"
 #include <array>
 #include <cfenv>
 #include <cmath>

--- a/fplll/enum/enumerate_ext.cpp
+++ b/fplll/enum/enumerate_ext.cpp
@@ -15,7 +15,7 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include "enumerate_ext.h"
-#include <fplll/defs.h>
+#include "../defs.h"
 
 #if FPLLL_MAX_PARALLEL_ENUM_DIM != 0
 #include "../enum-parallel/enumlib.h"

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -17,10 +17,10 @@
 #ifndef FPLLL_ENUMERATE_EXT_H
 #define FPLLL_ENUMERATE_EXT_H
 
-#include "enumerate_ext_api.h"
-#include "enumerate_base.h"
-#include "evaluator.h"
 #include "../gso_interface.h"
+#include "enumerate_base.h"
+#include "enumerate_ext_api.h"
+#include "evaluator.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -18,10 +18,9 @@
 #define FPLLL_ENUMERATE_EXT_H
 
 #include "enumerate_ext_api.h"
-
-#include <fplll/enum/enumerate_base.h>
-#include <fplll/enum/evaluator.h>
-#include <fplll/gso_interface.h>
+#include "enumerate_base.h"
+#include "evaluator.h"
+#include "../gso_interface.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/enum/evaluator.h
+++ b/fplll/enum/evaluator.h
@@ -16,9 +16,9 @@
 #ifndef FPLLL_EVALUATOR_H
 #define FPLLL_EVALUATOR_H
 
+#include "../gso_interface.h"
+#include "../util.h"
 #include <cassert>
-#include <fplll/gso_interface.h>
-#include <fplll/util.h>
 #include <functional>
 #include <map>
 #include <queue>

--- a/fplll/latticegen.cpp
+++ b/fplll/latticegen.cpp
@@ -15,7 +15,7 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "config.h"
+#include "../config.h"
 #include "util.h"
 
 using namespace fplll;

--- a/fplll/main.cpp
+++ b/fplll/main.cpp
@@ -16,7 +16,7 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include "main.h"
-#include <config.h>
+#include "../config.h"
 
 template <class ZT> int lll(Options &o, ZZ_mat<ZT> &b)
 {

--- a/fplll/nr/matrix.h
+++ b/fplll/nr/matrix.h
@@ -18,7 +18,7 @@
 #ifndef FPLLL_MATRIX_H
 #define FPLLL_MATRIX_H
 
-#include "fplll/nr/numvect.h"
+#include "numvect.h"
 
 FPLLL_BEGIN_NAMESPACE
 
@@ -371,6 +371,6 @@ public:
 
 FPLLL_END_NAMESPACE
 
-#include "fplll/nr/matrix.cpp"
+#include "matrix.cpp"
 
 #endif

--- a/fplll/nr/nr.h
+++ b/fplll/nr/nr.h
@@ -7,30 +7,29 @@
 #include "../defs.h"
 #include <iostream>
 
-#include "fplll/nr/nr_rand.inl"
+#include "nr_rand.inl"
 
-#include "fplll/nr/nr_Z.inl"
-#include "fplll/nr/nr_Z_d.inl"
-#include "fplll/nr/nr_Z_l.inl"
-#include "fplll/nr/nr_Z_mpz.inl"
-
-#include "fplll/nr/nr_FP.inl"
-#include "fplll/nr/nr_FP_d.inl"
-#include "fplll/nr/nr_FP_ld.inl"
+#include "nr_Z.inl"
+#include "nr_Z_d.inl"
+#include "nr_Z_l.inl"
+#include "nr_Z_mpz.inl"
+#include "nr_FP.inl"
+#include "nr_FP_d.inl"
+#include "nr_FP_ld.inl"
 
 #ifdef FPLLL_WITH_DPE
-#include "fplll/nr/nr_FP_dpe.inl"
+#include "nr_FP_dpe.inl"
 #endif
 
 #ifdef FPLLL_WITH_QD
-#include "fplll/nr/nr_FP_dd.inl"
-#include "fplll/nr/nr_FP_qd.inl"
+#include "nr_FP_dd.inl"
+#include "nr_FP_qd.inl"
 #endif
 
-#include "fplll/nr/nr_FP_mpfr.inl"
+#include "nr_FP_mpfr.inl"
 
-#include "fplll/nr/nr_FP_misc.inl"
-#include "fplll/nr/nr_Z_misc.inl"
+#include "nr_FP_misc.inl"
+#include "nr_Z_misc.inl"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/nr/nr.h
+++ b/fplll/nr/nr.h
@@ -9,13 +9,13 @@
 
 #include "nr_rand.inl"
 
+#include "nr_FP.inl"
+#include "nr_FP_d.inl"
+#include "nr_FP_ld.inl"
 #include "nr_Z.inl"
 #include "nr_Z_d.inl"
 #include "nr_Z_l.inl"
 #include "nr_Z_mpz.inl"
-#include "nr_FP.inl"
-#include "nr_FP_d.inl"
-#include "nr_FP_ld.inl"
 
 #ifdef FPLLL_WITH_DPE
 #include "nr_FP_dpe.inl"

--- a/fplll/nr/nr_Z_l.inl
+++ b/fplll/nr/nr_Z_l.inl
@@ -29,7 +29,7 @@ template <> inline void Z_NR<long>::get_mpz(mpz_t r) const { mpz_set_si(r, data)
 
 inline long compute_long_exponent(long data)
 {
-  unsigned long y = static_cast<unsigned long>(abs(data));
+  unsigned long y = static_cast<unsigned long>(std::abs(data));
   long e;
   for (e = 0; y; e++, y >>= 1)
   {

--- a/fplll/nr/numvect.h
+++ b/fplll/nr/numvect.h
@@ -16,7 +16,7 @@
 #ifndef FPLLL_NUMVECT_H
 #define FPLLL_NUMVECT_H
 
-#include "fplll/nr/nr.h"
+#include "nr.h"
 #include <vector>
 
 FPLLL_BEGIN_NAMESPACE

--- a/fplll/pruner/pruner.cpp
+++ b/fplll/pruner/pruner.cpp
@@ -14,9 +14,9 @@
   along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include "pruner.h"
-#include "ballvol.const"
-#include "factorial.const"
-#include "fplll.h"
+#include "../ballvol.const"
+#include "../factorial.const"
+#include "../fplll.h"
 
 // add components
 #include "pruner_cost.cpp"

--- a/fplll/pruner/pruner.h
+++ b/fplll/pruner/pruner.h
@@ -17,8 +17,8 @@
 #ifndef FPLLL_PRUNER_H
 #define FPLLL_PRUNER_H
 
-#include "fplll/defs.h"
-#include "fplll/lll.h"
+#include "../defs.h"
+#include "../lll.h"
 #include <vector>
 
 FPLLL_BEGIN_NAMESPACE

--- a/fplll/pruner/pruner_cost.cpp
+++ b/fplll/pruner/pruner_cost.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/pruner/pruner_optimize.cpp
+++ b/fplll/pruner/pruner_optimize.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/pruner/pruner_optimize_tc.cpp
+++ b/fplll/pruner/pruner_optimize_tc.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/pruner/pruner_optimize_tp.cpp
+++ b/fplll/pruner/pruner_optimize_tp.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/pruner/pruner_prob.cpp
+++ b/fplll/pruner/pruner_prob.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/pruner/pruner_util.cpp
+++ b/fplll/pruner/pruner_util.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/threadpool.cpp
+++ b/fplll/threadpool.cpp
@@ -13,7 +13,7 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include <fplll/threadpool.h>
+#include "threadpool.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/threadpool.h
+++ b/fplll/threadpool.h
@@ -16,8 +16,8 @@
 #ifndef FPLLL_THREADPOOL_H
 #define FPLLL_THREADPOOL_H
 
-#include <fplll/defs.h>
-#include <fplll/io/thread_pool.hpp>
+#include "defs.h"
+#include "io/thread_pool.hpp"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/tests/test_babai.cpp
+++ b/tests/test_babai.cpp
@@ -13,7 +13,7 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "fplll/fplll.h"
+#include <fplll/fplll.h>
 #include <vector>
 
 #include <cfloat>  // Needed for precision macros.

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -13,10 +13,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "io/json.hpp"
 #include <cstring>
-#include <fplll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include <fplll/io/json.hpp>
+#include "test_utils.h"
 
 using json = nlohmann::json;
 

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -13,10 +13,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
 #include <fplll/io/json.hpp>
-#include "test_utils.h"
 
 using json = nlohmann::json;
 

--- a/tests/test_bkz_gram.cpp
+++ b/tests/test_bkz_gram.cpp
@@ -14,12 +14,12 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
 #include <fplll/gso_gram.h>
 #include <fplll/gso_interface.h>
 #include <fplll/io/json.hpp>
-#include "test_utils.h"
 
 using json = nlohmann::json;
 

--- a/tests/test_bkz_gram.cpp
+++ b/tests/test_bkz_gram.cpp
@@ -14,12 +14,12 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "io/json.hpp"
 #include <cstring>
-#include <fplll.h>
-#include <gso_gram.h>
-#include <gso_interface.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include <fplll/gso_gram.h>
+#include <fplll/gso_interface.h>
+#include <fplll/io/json.hpp>
+#include "test_utils.h"
 
 using json = nlohmann::json;
 

--- a/tests/test_ceil.cpp
+++ b/tests/test_ceil.cpp
@@ -1,4 +1,4 @@
-#include "fplll/fplll.h"
+#include <fplll/fplll.h>
 
 using namespace fplll;
 

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -14,8 +14,8 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -13,9 +13,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
-#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -13,9 +13,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
-#include "test_utils.h"
 
 using namespace fplll;
 

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -15,7 +15,7 @@
 
 #include <cstring>
 #include <fplll/fplll.h>
-#include <test_utils.h>
+#include "test_utils.h"
 
 using namespace fplll;
 

--- a/tests/test_gso.cpp
+++ b/tests/test_gso.cpp
@@ -14,13 +14,13 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <gso.h>
-#include <gso_gram.h>
-#include <gso_interface.h>
-#include <householder.h>
-#include <nr/matrix.h>
+#include <fplll/gso.h>
+#include <fplll/gso_gram.h>
+#include <fplll/gso_interface.h>
+#include <fplll/householder.h>
+#include <fplll/nr/matrix.h>
 // #include <random>
-#include <test_utils.h>
+#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_hlll.cpp
+++ b/tests/test_hlll.cpp
@@ -14,9 +14,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
-#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_hlll.cpp
+++ b/tests/test_hlll.cpp
@@ -15,8 +15,8 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -13,9 +13,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
-#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -14,8 +14,8 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -14,13 +14,13 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
 #include <fplll/gso.h>
 #include <fplll/gso_gram.h>
 #include <fplll/gso_interface.h>
 #include <fplll/lll.h>
-#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -15,12 +15,12 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <gso.h>
-#include <gso_gram.h>
-#include <gso_interface.h>
-#include <lll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include <fplll/gso.h>
+#include <fplll/gso_gram.h>
+#include <fplll/gso_interface.h>
+#include <fplll/lll.h>
+#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_nr.cpp
+++ b/tests/test_nr.cpp
@@ -14,7 +14,7 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
+#include <fplll/fplll.h>
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_pruner.cpp
+++ b/tests/test_pruner.cpp
@@ -14,7 +14,7 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
+#include <fplll/fplll.h>
 
 #ifdef FPLLL_WITH_QD
 #include <qd/dd_real.h>

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -14,9 +14,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
-#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -15,8 +15,8 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_svp_gram.cpp
+++ b/tests/test_svp_gram.cpp
@@ -15,10 +15,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
 #include <fplll/gso_gram.h>
-#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_svp_gram.cpp
+++ b/tests/test_svp_gram.cpp
@@ -16,9 +16,9 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <gso_gram.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include <fplll/gso_gram.h>
+#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,7 +1,7 @@
 #ifndef TEST_UTILS_H
 #define TEST_UTILS_H 
 
-#include <fplll.h>
+#include <fplll/fplll.h>
 using namespace std;
 using namespace fplll;
 


### PR DESCRIPTION
Close #527 

As discussed, I unify all import style under `fplll/*` to relative path, and all under `tests/` to be system path (since tests normally assume built package and installed headers) 

~Also the `cmake` build config is only my best effort, and not super well tested. I locally run, the artifacts are as close to the `automake` tool as possible. Hopefully this is just pure additional and completely optional to the developers to use it.  (added the "unofficial" warning in README)~

~also happy to drop [12b49aa](https://github.com/fplll/fplll/pull/528/commits/12b49aaf25766369932aeeb01d469a8f786b7aaa) if it's undesirable~