### PR TITLE
fix convert mpz to long for u and u_inv in bkz.cpp. This hopefully fixes #525. 

### DIFF
--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -823,8 +823,7 @@ int bkz_reduction_f(ZZ_mat<mpz_t> &b, const BKZParam &param, int sel_ft, double 
   ZZ_mat<long> ul_inv;
 
   // we check if we can convert the basis to long integers for performance
-  if (convert<long, mpz_t>(bl, b, 10) && \
-      convert<long, mpz_t>(ul, u, 10) && \
+  if (convert<long, mpz_t>(bl, b, 10) && convert<long, mpz_t>(ul, u, 10) &&
       convert<long, mpz_t>(ul_inv, u_inv, 10))
   {
     MatGSO<Z_NR<long>, FT> m_gso(bl, ul, ul_inv, gso_flags);

--- a/fplll/bkz.cpp
+++ b/fplll/bkz.cpp
@@ -819,19 +819,18 @@ int bkz_reduction_f(ZZ_mat<mpz_t> &b, const BKZParam &param, int sel_ft, double 
   if (sel_ft == FT_DOUBLE || sel_ft == FT_LONG_DOUBLE)
     gso_flags |= GSO_ROW_EXPO;
   ZZ_mat<long> bl;
-  // we check if we can convert the basis to long integers for performance
-  if (convert<long, mpz_t>(bl, b, 10))
-  {
-    ZZ_mat<long> ul;
-    convert<long, mpz_t>(ul, u, 0);
-    ZZ_mat<long> ul_inv;
-    convert<long, mpz_t>(ul_inv, u_inv, 0);
+  ZZ_mat<long> ul;
+  ZZ_mat<long> ul_inv;
 
+  // we check if we can convert the basis to long integers for performance
+  if (convert<long, mpz_t>(bl, b, 10) && \
+      convert<long, mpz_t>(ul, u, 10) && \
+      convert<long, mpz_t>(ul_inv, u_inv, 10))
+  {
     MatGSO<Z_NR<long>, FT> m_gso(bl, ul, ul_inv, gso_flags);
     LLLReduction<Z_NR<long>, FT> lll_obj(m_gso, lll_delta, LLL_DEF_ETA, LLL_DEFAULT);
     BKZReduction<Z_NR<long>, FT> bkz_obj(m_gso, lll_obj, param);
     bkz_obj.bkz();
-
     convert<mpz_t, long>(b, bl, 0);
     convert<mpz_t, long>(u, ul, 0);
     convert<mpz_t, long>(u_inv, ul_inv, 0);


### PR DESCRIPTION
In bkz.cpp, the function bkz_reduction_f() only checks if the input basis b fits into the long with:

convert<long, mpz_t>(bl, b, 10)

The pull request also checks whether the input u and u_inv fit into the long. 

This hopefully fixes #525. 

