### PR TITLE
feat: add optional cmake support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,7 @@ stamp-h1
 /tests/test_sieve
 /tests/test_svp
 /tests/test_svp_gram
+**/*.DS_Store
+config.guess~
+config.sub~
+install-sh~

--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,14 @@ stamp-h1
 /tests/test_sieve
 /tests/test_svp
 /tests/test_svp_gram
-**/*.DS_Store
+/tests/test_babai
+/tests/test_counter
+tests/test_ceil
+/.cache/
+/configure~
 config.guess~
 config.sub~
 install-sh~
+*.DS_Store
+**/*.log
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,403 @@
+# User note:
+# This aims to work almost identical to libtool-based compilation pipeline.
+# At project root, run:
+# $ mkdir build && cd build/
+# $ cmake -DMAKE_INSTALL_PREFIX=$VIRTUAL_ENV ..
+
+# Minimum required CMake version
+cmake_minimum_required(VERSION 3.10)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Project/Package name and version
+project(fplll VERSION 5.4.5)
+set(FPLLL_MAJOR_VERSION ${fplll_VERSION_MAJOR})
+set(FPLLL_MINOR_VERSION ${fplll_VERSION_MINOR})
+set(FPLLL_MICRO_VERSION ${fplll_VERSION_PATCH})
+set(FPLLL_VERSION ${fplll_VERSION})
+
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  if(CMAKE_CXX_COMPILER_VERSION MATCHES "^14.")
+    message(STATUS "You're using ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+  else()
+    message(WARNING "!! We recommend that you use clang-14 for this bootcamp. You're using ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}, a different version.")
+  endif()
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+  message(STATUS "You're using ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+else()
+  message(WARNING "!! We recommend that you use clang-14 for this bootcamp. You're using ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}, which is not clang.")
+endif()
+
+# standard library use c++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_SYSROOT $ENV{SDKROOT})
+
+# Find system dependencies
+# GMP
+find_path(GMP_INCLUDE_DIR gmp.h PATHS /opt/homebrew/include /opt/homebrew/opt/gmp/include)
+find_library(GMP_LIBRARY NAMES gmp libgmp PATHS /opt/homebrew/lib /opt/homebrew/opt/gmp/lib)
+if (GMP_INCLUDE_DIR AND GMP_LIBRARY)
+  set(GMP_FOUND TRUE)
+  set(HAVE_LIBGMP 1)
+  set(LIBGMP_LIB "-lgmp")
+  message(STATUS "Found GMP: ${GMP_LIBRARY}")
+else ()
+  set(GMP_FOUND FALSE)
+  message(FATAL_ERROR "GMP not found")
+endif ()
+mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARY)
+
+# MPFR
+find_path(MPFR_INCLUDE_DIR mpfr.h PATHS /opt/homebrew/include /opt/homebrew/opt/mpfr/include)
+find_library(MPFR_LIBRARY NAMES mpfr libmpfr PATHS /opt/homebrew/lib /opt/homebrew/opt/mpfr/lib)
+if (MPFR_INCLUDE_DIR AND MPFR_LIBRARY)
+  set(MPFR_FOUND TRUE)
+  set(HAVE_LIBMPFR 1)
+  set(LIBMPFR_LIB "-lmpfr")
+  message(STATUS "Found MPFR: ${MPFR_LIBRARY}")
+else ()
+  set(MPFR_FOUND FALSE)
+  message(FATAL_ERROR "MPFR not found")
+endif ()
+mark_as_advanced(MPFR_INCLUDE_DIR MPFR_LIBRARY)
+
+# QD (Optional)
+find_path(QD_INCLUDE_DIR qd/dd_real.h PATHS /opt/homebrew/include /opt/homebrew/opt/qd/include)
+find_library(QD_LIBRARY NAMES qd libqd PATHS /opt/homebrew/lib /opt/homebrew/opt/qd/lib)
+if (QD_INCLUDE_DIR AND QD_LIBRARY)
+  set(QD_FOUND TRUE)
+  set(FPLLL_WITH_QD 1)
+  set(LIBQD_LIB "-lqd")
+  message(STATUS "Found QD: ${QD_LIBRARY}")
+else ()
+  set(QD_FOUND FALSE)
+  message(WARNING "QD not found, proceeding without QD")
+endif ()
+mark_as_advanced(QD_INCLUDE_DIR QD_LIBRARY)
+
+find_package(Threads REQUIRED)
+include(CheckCXXSourceCompiles)
+if(Threads_FOUND)
+  set(HAVE_PTHREAD 1)
+  set(PTHREAD_LIB "-lpthread")
+  set(PTHREAD_CFLAGS "-pthread")
+  check_cxx_source_compiles("
+    #include <pthread.h>
+    int main() {
+        pthread_mutexattr_t attr;
+        return pthread_mutexattr_setprotocol(&attr, PTHREAD_PRIO_INHERIT);
+    }
+  " HAVE_PTHREAD_PRIO_INHERIT)
+else()
+  message(STATUS "pthread headers and libraries not found")
+endif()
+
+# Define project specific variables
+# TODO: (alex) revert
+# set(FPLLL_MAX_ENUM_DIM 256)
+set(FPLLL_MAX_ENUM_DIM 0)
+set(FPLLL_WITH_RECURSIVE_ENUM 1)
+# TODO: (alex) revert
+# set(FPLLL_MAX_PARALLEL_ENUM_DIM 120)
+set(FPLLL_MAX_PARALLEL_ENUM_DIM 0)
+
+# Use external enumeration
+option(WITH_EXTENUM_DIR "Specify external enumeration library install directory" OFF)
+if(WITH_EXTENUM_DIR)
+    link_directories(${WITH_EXTENUM_DIR})
+endif()
+
+option(WITH_EXTENUM_LIB "Specify external enumeration library name" OFF)
+if(WITH_EXTENUM_LIB)
+    set(EXTENUM_LIB ${WITH_EXTENUM_LIB})
+endif()
+
+option(WITH_EXTENUM_FUNC "Specify external enumeration function name" OFF)
+if(WITH_EXTENUM_FUNC)
+    set(EXTENUM_FUNC ${WITH_EXTENUM_FUNC})
+endif()
+
+if(EXTENUM_LIB)
+    if(NOT EXTENUM_FUNC)
+        set(EXTENUM_FUNC ${EXTENUM_LIB})
+    endif()
+    try_compile(EXTENUM_LINK_SUCCESS ${CMAKE_BINARY_DIR} SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/extenum_check.cpp
+        LINK_LIBRARIES ${EXTENUM_LIB}
+    )
+    if(NOT EXTENUM_LINK_SUCCESS)
+        message(FATAL_ERROR "Failed to find external enumeration")
+    endif()
+    set(EXTENUM_LIBS "-l${EXTENUM_LIB}")
+    add_definitions(-DFPLLL_EXTENUM_FUNC=${EXTENUM_FUNC})
+endif()
+set(EXTENUM_LIBS "${EXTENUM_LIBS}" CACHE STRING "External enumeration libraries")
+
+# Include directories
+include_directories(${GMP_INCLUDE_DIR} ${MPFR_INCLUDE_DIR} ${QD_INCLUDE_DIR})
+set(LIBS "${LIBGMP_LIB} ${LIBMPFR_LIB} ${LIBQD_LIB} ${PTHREAD_LIB}")
+message(STATUS "LIBS: ${LIBS}")
+
+# setup fplll/fplll_config.h
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/fplll/fplll_config.cmake.h.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/fplll/fplll_config.h
+  @ONLY)
+
+# setup ./config.h
+include(CheckIncludeFileCXX)
+include(CheckFunctionExists)
+include(CheckTypeSize)
+set(CMAKE_REQUIRED_FLAGS "-isysroot ${CMAKE_SYSROOT}")
+check_include_file_cxx(cstdio HAVE_CSTDIO)
+check_include_file_cxx(iostream HAVE_IOSTREAM)
+check_include_file_cxx(string HAVE_STRING)
+check_include_file_cxx(vector HAVE_VECTOR)
+check_include_file_cxx(cstdint HAVE_CXX11)
+check_include_file_cxx(limits HAVE_LIMITS)
+check_include_file_cxx(limits.h HAVE_LIMITS_H)
+check_include_file_cxx(dlfcn.h HAVE_DLFCN_H)
+check_include_file_cxx(inttypes.h HAVE_INTTYPES_H)
+check_include_file_cxx(stdbool.h HAVE_STDBOOL_H)
+check_include_file_cxx(stdint.h HAVE_STDINT_H)
+check_include_file_cxx(stdio.h HAVE_STDIO_H)
+check_include_file_cxx(stdlib.h HAVE_STDLIB_H)
+check_include_file_cxx(strings.h HAVE_STRINGS_H)
+check_include_file_cxx(string.h HAVE_STRING_H)
+check_include_file_cxx(sys/stat.h HAVE_SYS_STAT_H)
+check_include_file_cxx(sys/types.h HAVE_SYS_TYPES_H)
+check_include_file_cxx(unistd.h HAVE_UNISTD_H)
+check_function_exists(floor HAVE_FLOOR)
+check_function_exists(pow HAVE_POW)
+check_function_exists(rint HAVE_RINT)
+check_function_exists(sqrt HAVE_SQRT)
+check_function_exists(strtol HAVE_STRTOL)
+check_type_size("_Bool" HAVE__BOOL LANGUAGE C)
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.cmake.h.in
+  ${CMAKE_CURRENT_SOURCE_DIR}/config.h
+  @ONLY)
+
+# Set up fplll package, corresponding to fplll/Makefile.am and ./fplll.pc.in
+# NOTE: ignored distribution related stuff, EXTRA_DIST not translated over
+include(GNUInstallDirs)
+
+set(FPLLL_PKG_CONFIG "${CMAKE_CURRENT_SOURCE_DIR}/fplll.pc")
+# setup fplll.pc for package
+configure_file(
+  ${CMAKE_CURRENT_SOURCE_DIR}/fplll.cmake.pc.in
+  ${FPLLL_PKG_CONFIG}
+  @ONLY)
+
+# Compiler flags
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3")
+## enabled via -DDEBUG
+if(DEBUG)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+endif()
+
+# $(srcdir) in Makefile.am
+set(FPLLL_SRCDIR "${CMAKE_CURRENT_SOURCE_DIR}/fplll")
+# $(include_fpllldir) in Makefile.am
+set(FPLLL_PKG_INCLUDEDIR "${CMAKE_INSTALL_FULL_INCLUDEDIR}/fplll")
+# $(pkgconfigdir) in Makefile.am
+set(FPLLL_PKG_CONFIGDIR "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
+# $(pkgdatadir) in Makefile.am
+set(FPLLL_PKG_DATADIR "${CMAKE_INSTALL_FULL_DATADIR}/fplll")
+# $(strategydir) in Makefile.am
+set(FPLLL_PKG_STRATEGYDIR "${FPLLL_PKG_DATADIR}/strategies")
+
+# === libfplll, fplll headers ===
+# FPLLL_LT_CURRENT in autoconf
+set(LIBFPLLL_MAJOR_VERSION 8)
+# FPLLL_LT_REVISION in autoconf
+set(LIBFPLLL_MINOR_VERSION 1)
+# FPLLL_LT_AGE in autoconf
+set(LIBFPLLL_MICRO_VERSION 0)
+# NOTE: this is library version, different from overall package/project version
+set(LIBFPLLL_VERSION "${LIBFPLLL_MAJOR_VERSION}.${LIBFPLLL_MINOR_VERSION}.${LIBFPLLL_MICRO_VERSION}")
+
+# Specify the additional files to be cleaned in the current directory
+set(COVERAGE_ARTIFACTS "*.gcov" ".libs/*.gcda" ".libs/*.gcno" "*.gcno" "*.gcda")
+set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${COVERAGE_ARTIFACTS}")
+
+set(LIBFPLLL_SOURCES
+  fplll.cpp fplll.h
+  util.cpp util.h
+  enum/topenum.cpp enum/topenum.h
+  enum/enumerate.cpp enum/enumerate.h
+  enum/enumerate_base.cpp enum/enumerate_base.h
+  enum/enumerate_ext.cpp enum/enumerate_ext.h enum/enumerate_ext_api.h
+  enum/evaluator.cpp enum/evaluator.h
+  lll.cpp lll.h
+  wrapper.cpp wrapper.h
+  bkz.cpp bkz.h
+  bkz_param.cpp bkz_param.h
+  gso_interface.cpp gso_interface.h gso_gram.cpp gso_gram.h gso.cpp gso.h
+  pruner/pruner.cpp
+  pruner/pruner.h
+  pruner/pruner_simplex.h
+  pruner/pruner_cost.cpp
+  pruner/pruner_optimize.cpp
+  pruner/pruner_optimize_tc.cpp
+  pruner/pruner_optimize_tp.cpp
+  pruner/pruner_prob.cpp
+  pruner/pruner_util.cpp
+  householder.cpp householder.h hlll.cpp hlll.h
+  io/json.hpp
+  threadpool.h threadpool.cpp io/thread_pool.hpp
+)
+if (FPLLL_MAX_PARALLEL_ENUM_DIM GREATER 0)
+  list(APPEND LIBFPLLL_SOURCES
+    enum-parallel/enumeration.h enum-parallel/enumlib.h enum-parallel/fplll_types.h
+    enum-parallel/enumlib.cpp
+    enum-parallel/enumlib_dim.160.cpp enum-parallel/enumlib_dim.150.cpp enum-parallel/enumlib_dim.140.cpp enum-parallel/enumlib_dim.130.cpp
+    enum-parallel/enumlib_dim.120.cpp enum-parallel/enumlib_dim.110.cpp enum-parallel/enumlib_dim.100.cpp enum-parallel/enumlib_dim.90.cpp
+    enum-parallel/enumlib_dim.80.cpp enum-parallel/enumlib_dim.70.cpp enum-parallel/enumlib_dim.60.cpp enum-parallel/enumlib_dim.50.cpp
+    enum-parallel/enumlib_dim.40.cpp enum-parallel/enumlib_dim.30.cpp enum-parallel/enumlib_dim.20.cpp
+  )
+endif()
+list(TRANSFORM LIBFPLLL_SOURCES PREPEND "fplll/")
+# NOTE: EXTRA_libfplll_la_SOURCES+ are already included in the above sources
+# e.g. svpcvp.cpp is included in fplll.cpp
+# e.g. enumlib_dim.cpp is included in any enumlib_dim.x.cpp
+
+
+# First define the (versioned) dynamic library
+add_library(libfplll_dynlib SHARED ${LIBFPLLL_SOURCES})
+add_library(libfplll_static STATIC ${LIBFPLLL_SOURCES})
+if(DEBUG)
+  add_library(libfplll_debug SHARED ${LIBFPLLL_SOURCES})
+endif()
+
+# libfplll_la_LIBADD in fplll/Makefile.am
+set(LIBFPLLL_LIBS "${LIBS} ${EXTENUM_LIB}")
+string(STRIP ${LIBFPLLL_LIBS} LIBFPLLL_LIBS) # remove leading and trailing whitespaces
+target_link_libraries(libfplll_dynlib PRIVATE ${LIBFPLLL_LIBS})
+target_link_libraries(libfplll_static PRIVATE ${LIBFPLLL_LIBS})
+if(DEBUG)
+  target_link_libraries(libfplll_debug PRIVATE ${LIBFPLLL_LIBS})
+endif()
+
+# libfplll_la_LDFLAGS in fplll/Makefile.am
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  target_link_options(libfplll_dynlib PRIVATE
+    -Wl,-no-undefined
+    -Wl,-version-info ${LIBFPLLL_VERSION}
+    ${PTHREAD_CFLAGS}
+  )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_link_options(libfplll_dynlib PRIVATE
+    # MacOS's ld already err on undefined by default
+    -Wl,-current_version,${LIBFPLLL_VERSION}
+    ${PTHREAD_CFLAGS}
+  )
+endif()
+
+# libfplll_la_CXXFLAGS in fplll/Makefile.am
+separate_arguments(CXXFLAGS_LIST UNIX_COMMAND "${CMAKE_CXX_FLAGS} ${PTHREAD_CFLAGS}")
+target_compile_options(libfplll_dynlib PRIVATE ${CXXFLAGS_LIST})
+target_compile_options(libfplll_static PRIVATE ${CXXFLAGS_LIST})
+if(DEBUG)
+  separate_arguments(CXXFLAGS_DEBUG_LIST UNIX_COMMAND "-DDEBUG ${CMAKE_CXX_FLAGS} ${PTHREAD_CFLAGS}")
+  target_compile_options(libfplll_debug PRIVATE ${CXXFLAGS_DEBUG_LIST})
+endif()
+
+set_target_properties(libfplll_dynlib PROPERTIES
+  PREFIX "" # already have lib prefix in the name
+  OUTPUT_NAME "libfplll"
+  VERSION ${LIBFPLLL_VERSION}
+)
+set_target_properties(libfplll_static PROPERTIES
+  PREFIX ""
+  OUTPUT_NAME "libfplll"
+  VERSION ${LIBFPLLL_VERSION}
+)
+if(DEBUG)
+  set_target_properties(libfplll_debug PROPERTIES
+    PREFIX ""
+    OUTPUT_NAME "libfpllld"
+    VERSION ${LIBFPLLL_VERSION}
+  )
+endif()
+
+
+# header files to include/
+install(
+  DIRECTORY ${FPLLL_SRCDIR}
+  TYPE INCLUDE
+  FILES_MATCHING
+  PATTERN "*.h"
+  PATTERN "nr/matrix.cpp"
+  PATTERN "*.hpp"
+  PATTERN "*.inl"
+  PATTERN "main.h" EXCLUDE
+  PATTERN ".deps" EXCLUDE
+  PATTERN ".libs" EXCLUDE
+)
+# dylib to lib/
+install(TARGETS libfplll_dynlib libfplll_static DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR})
+
+# fplll bin
+add_executable(fplll fplll/main.cpp fplll/main.h config.h)
+add_dependencies(fplll libfplll_static)
+set(FPLLL_LIBS "${LIBS} ${EXTENUM_LIB} ${CMAKE_CURRENT_BINARY_DIR}/libfplll.a")
+string(STRIP ${FPLLL_LIBS} FPLLL_LIBS) # remove leading and trailing whitespaces
+target_link_libraries(fplll PRIVATE ${FPLLL_LIBS})
+install(TARGETS fplll DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+
+if(DEBUG)
+  add_executable(fplll_debug fplll/main.cpp fplll/main.h config.h)
+  add_dependencies(fplll_debug libfplll_static)
+  target_compile_options(fplll_debug PRIVATE ${CXXFLAGS_DEBUG_LIST})
+  target_link_libraries(fplll_debug PRIVATE ${FPLLL_LIBS})
+  install(TARGETS fplll_debug DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+endif()
+
+# latticegen bin
+add_executable(latticegen fplll/latticegen.cpp config.h)
+add_dependencies(latticegen libfplll_static)
+target_link_libraries(latticegen PRIVATE ${FPLLL_LIBS})
+install(TARGETS latticegen DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+
+if(DEBUG)
+  add_executable(latticegen_debug fplll/latticegen.cpp config.h)
+  add_dependencies(latticegen_debug libfplll_static)
+  target_compile_options(latticegen_debug PRIVATE ${CXXFLAGS_DEBUG_LIST})
+  target_link_libraries(latticegen_debug PRIVATE ${FPLLL_LIBS})
+  install(TARGETS latticegen_debug DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+endif()
+
+
+# llldiff bin
+add_executable(llldiff fplll/llldiff.cpp config.h)
+add_dependencies(llldiff libfplll_static)
+target_link_libraries(llldiff PRIVATE ${FPLLL_LIBS})
+install(TARGETS llldiff DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+
+# Define preprocessor definitions
+add_compile_definitions(
+  FPLLL_DEFAULT_STRATEGY_PATH="${FPLLL_PKG_STRATEGYDIR}"
+  FPLLL_DEFAULT_STRATEGY="${FPLLL_PKG_STRATEGYDIR}/default.json"
+)
+install(FILES ${FPLLL_PKG_CONFIG} DESTINATION ${FPLLL_PKG_CONFIGDIR})
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/strategies/default.json" DESTINATION ${FPLLL_PKG_STRATEGYDIR})
+
+# tests
+# ${TOPSRCDIR} in tests/Makefile.am
+set(TOPSRCDIR ${CMAKE_CURRENT_SOURCE_DIR})
+find_path(INSTALLED_FPLLL_H fplll.h PATHS "${FPLLL_PKG_INCLUDEDIR}")
+if (INSTALLED_FPLLL_H)
+  add_subdirectory(tests)
+else()
+  message(WARNING "run `make install` to install header files, then run `make` again")
+endif()
+
+# extra Makefile target
+set(CLANGFORMAT "clang-format")
+add_custom_target(check-style
+    COMMAND ${CMAKE_COMMAND} -E echo "Running style checks..."
+    COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/.check-m4.sh
+    COMMAND ${CLANGFORMAT} -i --style=file ${CMAKE_CURRENT_SOURCE_DIR}/fplll/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/fplll/*.h ${CMAKE_CURRENT_SOURCE_DIR}/fplll/*/*.cpp ${CMAKE_CURRENT_SOURCE_DIR}/fplll/*/*.h ${CMAKE_CURRENT_SOURCE_DIR}/fplll/*/*.inl ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Checking code style with clang-format"
+)

--- a/README.md
+++ b/README.md
@@ -113,6 +113,27 @@ fplll can also be built from source. Below, we explicate some of the dependencie
   
 NOTE: If you are intending to use fplll on Windows 10, then these packages should be installed after the `Windows Subsystem for Linux` has been installed and activated. Please go to the [Windows 10](#windows-10) instructions for more information.
 
+### Using `cmake` instead of `libtools` and `auto[conf|make]` ###
+
+_Note:_ the `CMakeLists.txt` configuration is unofficial and trying to reproduce the official build as close as possible, however, less tested cross-platforms.
+
+One upside of `cmake` is, it will generate compilation database automatically at `build/compile_commands.json` which integrates well with language server like `clangd`.
+
+``` sh
+mkdir build && cd build/
+# default for MAKE_INSTALL_PREFIX=/usr/local
+cmake -DMAKE_INSTALL_PREFIX=$VIRTUAL_ENV ..
+make
+make install # this will install headers, libfplll.dylib, libfplll.a, fplll, latticegen, llldiff
+
+# additionally, if this is your first time
+# run `cmake` again to build test files, as they depend on installed headers from previous `make install`
+# in the future, no more `cmake`, your Makefile is good for go
+cmake -DMAKE_INSTALL_PREFIX=$VIRTUAL_ENV ..
+make build_tests
+make test
+```
+
 ### Linux and MacOS ###
 
 You should download the source code from Github and then run

--- a/config.cmake.h.in
+++ b/config.cmake.h.in
@@ -1,0 +1,173 @@
+/* major version */
+#define FPLLL_MAJOR_VERSION @FPLLL_MAJOR_VERSION@
+
+/* micro version */
+#define FPLLL_MICRO_VERSION @FPLLL_MICRO_VERSION@
+
+/* minor version */
+#define FPLLL_MINOR_VERSION @FPLLL_MINOR_VERSION@
+
+/* full version */
+#define FPLLL_VERSION @FPLLL_VERSION@
+
+/* long version string */
+#define FPLLL_VERSION_INFO @FPLLL_VERSION_INFO@
+
+/* defined when libqd is usable */
+#cmakedefine FPLLL_WITH_QD
+
+/* parallel enumeration enabled */
+#define FPLLL_MAX_PARALLEL_ENUM_DIM @FPLLL_MAX_PARALLEL_ENUM_DIM@
+
+/* recursive enumeration enabled */
+#define FPLLL_WITH_RECURSIVE_ENUM @FPLLL_WITH_RECURSIVE_ENUM@
+
+/* maximum supported enumeration dimension */
+#define FPLLL_MAX_ENUM_DIM @FPLLL_MAX_ENUM_DIM@
+
+/* use external enumeration function */
+#cmakedefine FPLLL_EXTENUM_FUNC
+
+/* Switch between GMP and MPIR */
+#if @HAVE_LIBGMP@
+#define HAVE_LIBGMP 1
+#else
+#define HAVE_LIBMPIR 1
+#endif
+
+/* Define to 1 if you have the 'mpfr' library (-lmpfr). */
+#cmakedefine HAVE_LIBMPFR
+
+/* Define to 1 if you have the <limits.h> header file. */
+#cmakedefine HAVE_LIMITS_H
+
+/* Define to 1 if you have the <cstdio> header file. */
+#cmakedefine HAVE_CSTDIO
+
+/* Define to 1 if you have the <iostream> header file. */
+#cmakedefine HAVE_IOSTREAM
+
+/* Define to 1 if you have the <string> header file. */
+#cmakedefine HAVE_STRING
+
+/* Define to 1 if you have the <vector> header file. */
+#cmakedefine HAVE_VECTOR
+
+/* define if the compiler supports basic C++11 syntax */
+#cmakedefine HAVE_CXX11
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#cmakedefine HAVE_DLFCN_H
+
+/* Define to 1 if you have the 'floor' function. */
+#cmakedefine HAVE_FLOOR
+
+/* Define to 1 if you have the 'pow' function. */
+#cmakedefine HAVE_POW
+
+/* Define to 1 if you have the 'rint' function. */
+#cmakedefine HAVE_RINT
+
+/* Define to 1 if you have the 'sqrt' function. */
+#cmakedefine HAVE_SQRT
+
+/* Define to 1 if you have the 'strtol' function. */
+#cmakedefine HAVE_STRTOL
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H
+
+/* Define to 1 if you have the <limits> header file. */
+#cmakedefine HAVE_LIMITS
+
+/* Define if you have POSIX threads libraries and header files. */
+#cmakedefine HAVE_PTHREAD
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#cmakedefine HAVE_PTHREAD_PRIO_INHERIT
+
+/* Define to 1 if stdbool.h conforms to C99. */
+#cmakedefine HAVE_STDBOOL_H
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#cmakedefine HAVE_STDIO_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#cmakedefine HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#cmakedefine HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H
+
+/* Define to 1 if the system has the type '_Bool'. */
+#cmakedefine HAVE__BOOL
+
+/* Not using libtool, using cmake instead */
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+/* #undef LT_OBJDIR */
+
+/* Name of package */
+#define PACKAGE "@PROJECT_NAME@"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "@PROJECT_BUGREPORT@"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "@PROJECT_NAME@"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "@PROJECT_NAME@ @FPLLL_VERSION@"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "@PROJECT_NAME@"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "@PROJECT_HOMEPAGE_URL@"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@FPLLL_VERSION@"
+
+/* Version number of package */
+#define VERSION "@FPLLL_VERSION@"
+
+/* NOTE: for all below, since c++11 is supported, skip checking for simplicity */
+/* should work for most modern setups */
+
+/* Define to 1 if all of the C89 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+/* #undef STDC_HEADERS */
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+/* #undef PTHREAD_CREATE_JOINABLE */
+
+/* Define to empty if 'const' does not conform to ANSI C. */
+/* #undef const */
+
+/* Define to '__inline__' or '__inline' if that's what the C compiler
+   calls it, or to nothing if 'inline' is not supported under any name.  */
+#ifndef __cplusplus
+/* #undef inline */
+#endif
+
+/* Define as 'unsigned int' if <stddef.h> doesn't define. */
+/* #undef size_t */
+
+/* Define to empty if the keyword 'volatile' does not work. Warning: valid
+   code using 'volatile' can become incorrect without. Disable with care. */
+/* #undef volatile */

--- a/fplll.cmake.pc.in
+++ b/fplll.cmake.pc.in
@@ -1,0 +1,10 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+
+Name: @PROJECT_NAME@
+Description: lattice algorithms with floating-point computations
+Version: @PROJECT_VERSION@
+Cflags: -I@CMAKE_INSTALL_FULL_INCLUDEDIR@ @PTHREAD_CFLAGS@
+Libs: -L@CMAKE_INSTALL_FULL_LIBDIR@ @LIBQD_LIBS@ @PTHREAD_LIBS@ @LIBS@ -lfplll

--- a/fplll/Makefile.am
+++ b/fplll/Makefile.am
@@ -7,9 +7,7 @@ EXTRA_DIST = io/json.hpp ballvol.const factorial.const
 
 CLEANFILES = *.gcov .libs/*.gcda .libs/*.gcno *.gcno *.gcda */*.gcno */*.gcda
 
-nodist_include_fplll_HEADERS=fplll_config.h
-
-nobase_include_fplll_HEADERS=defs.h fplll.h \
+nobase_include_fplll_HEADERS=defs.h fplll.h fplll_config.h \
 	nr/dpe.h \
 	nr/matrix.h \
 	nr/matrix.cpp \

--- a/fplll/enum/enumerate.h
+++ b/fplll/enum/enumerate.h
@@ -19,10 +19,10 @@
 #ifndef FPLLL_ENUMERATE_H
 #define FPLLL_ENUMERATE_H
 
+#include "../gso_interface.h"
 #include "enumerate_base.h"
 #include "enumerate_ext.h"
 #include "evaluator.h"
-#include "../gso_interface.h"
 #include <array>
 #include <memory>
 

--- a/fplll/enum/enumerate.h
+++ b/fplll/enum/enumerate.h
@@ -19,11 +19,11 @@
 #ifndef FPLLL_ENUMERATE_H
 #define FPLLL_ENUMERATE_H
 
+#include "enumerate_base.h"
+#include "enumerate_ext.h"
+#include "evaluator.h"
+#include "../gso_interface.h"
 #include <array>
-#include <fplll/enum/enumerate_base.h>
-#include <fplll/enum/enumerate_ext.h>
-#include <fplll/enum/evaluator.h>
-#include <fplll/gso_interface.h>
 #include <memory>
 
 FPLLL_BEGIN_NAMESPACE

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -19,9 +19,9 @@
 #ifndef FPLLL_ENUMERATE_BASE_H
 #define FPLLL_ENUMERATE_BASE_H
 
-#include "./enumerate_ext_api.h"
 #include "../fplll_config.h"
 #include "../nr/nr.h"
+#include "./enumerate_ext_api.h"
 #include <array>
 #include <cfenv>
 #include <cmath>

--- a/fplll/enum/enumerate_base.h
+++ b/fplll/enum/enumerate_base.h
@@ -19,9 +19,9 @@
 #ifndef FPLLL_ENUMERATE_BASE_H
 #define FPLLL_ENUMERATE_BASE_H
 
-#include "fplll/enum/enumerate_ext_api.h"
-#include "fplll/fplll_config.h"
-#include "fplll/nr/nr.h"
+#include "./enumerate_ext_api.h"
+#include "../fplll_config.h"
+#include "../nr/nr.h"
 #include <array>
 #include <cfenv>
 #include <cmath>

--- a/fplll/enum/enumerate_ext.cpp
+++ b/fplll/enum/enumerate_ext.cpp
@@ -15,7 +15,7 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include "enumerate_ext.h"
-#include <fplll/defs.h>
+#include "../defs.h"
 
 #if FPLLL_MAX_PARALLEL_ENUM_DIM != 0
 #include "../enum-parallel/enumlib.h"

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -17,10 +17,10 @@
 #ifndef FPLLL_ENUMERATE_EXT_H
 #define FPLLL_ENUMERATE_EXT_H
 
-#include "enumerate_ext_api.h"
-#include "enumerate_base.h"
-#include "evaluator.h"
 #include "../gso_interface.h"
+#include "enumerate_base.h"
+#include "enumerate_ext_api.h"
+#include "evaluator.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/enum/enumerate_ext.h
+++ b/fplll/enum/enumerate_ext.h
@@ -18,10 +18,9 @@
 #define FPLLL_ENUMERATE_EXT_H
 
 #include "enumerate_ext_api.h"
-
-#include <fplll/enum/enumerate_base.h>
-#include <fplll/enum/evaluator.h>
-#include <fplll/gso_interface.h>
+#include "enumerate_base.h"
+#include "evaluator.h"
+#include "../gso_interface.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/enum/evaluator.h
+++ b/fplll/enum/evaluator.h
@@ -16,9 +16,9 @@
 #ifndef FPLLL_EVALUATOR_H
 #define FPLLL_EVALUATOR_H
 
+#include "../gso_interface.h"
+#include "../util.h"
 #include <cassert>
-#include <fplll/gso_interface.h>
-#include <fplll/util.h>
 #include <functional>
 #include <map>
 #include <queue>

--- a/fplll/fplll_config.cmake.h.in
+++ b/fplll/fplll_config.cmake.h.in
@@ -1,0 +1,41 @@
+#ifndef FPLLL_CONFIG__H
+#define FPLLL_CONFIG__H
+
+/* use quaddouble library */
+#cmakedefine FPLLL_WITH_QD
+
+/* fplll major version */
+#define FPLLL_MAJOR_VERSION @FPLLL_MAJOR_VERSION@
+
+/* fplll minor version */
+#define FPLLL_MINOR_VERSION @FPLLL_MINOR_VERSION@
+
+/* fplll micro version */
+#define FPLLL_MICRO_VERSION @FPLLL_MICRO_VERSION@
+
+/* fplll version */
+#define FPLLL_VERSION @FPLLL_VERSION@
+
+/* fplll version info */
+#define FPLLL_VERSION_INFO @FPLLL_VERSION_INFO@
+
+/* Maximum supported enumeration dimension */
+#define FPLLL_MAX_ENUM_DIM @FPLLL_MAX_ENUM_DIM@
+
+/* Recursive enumeration enabled */
+#cmakedefine FPLLL_WITH_RECURSIVE_ENUM
+
+/* Maximum supported parallel enumeration dimension */
+#define FPLLL_MAX_PARALLEL_ENUM_DIM @FPLLL_MAX_PARALLEL_ENUM_DIM@
+
+/* Switch between GMP and MPIR */
+#if @HAVE_LIBGMP@
+#define HAVE_LIBGMP 1
+#else
+#define HAVE_LIBMPIR 1
+#endif
+
+/* external enumeration */
+#cmakedefine FPLLL_EXTENUM_FUNC
+
+#endif //FPLLL_CONFIG__H

--- a/fplll/latticegen.cpp
+++ b/fplll/latticegen.cpp
@@ -15,7 +15,7 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "config.h"
+#include "../config.h"
 #include "util.h"
 
 using namespace fplll;

--- a/fplll/main.cpp
+++ b/fplll/main.cpp
@@ -16,7 +16,7 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include "main.h"
-#include <config.h>
+#include "../config.h"
 
 template <class ZT> int lll(Options &o, ZZ_mat<ZT> &b)
 {

--- a/fplll/nr/matrix.h
+++ b/fplll/nr/matrix.h
@@ -18,7 +18,7 @@
 #ifndef FPLLL_MATRIX_H
 #define FPLLL_MATRIX_H
 
-#include "fplll/nr/numvect.h"
+#include "numvect.h"
 
 FPLLL_BEGIN_NAMESPACE
 
@@ -371,6 +371,6 @@ public:
 
 FPLLL_END_NAMESPACE
 
-#include "fplll/nr/matrix.cpp"
+#include "matrix.cpp"
 
 #endif

--- a/fplll/nr/nr.h
+++ b/fplll/nr/nr.h
@@ -7,30 +7,29 @@
 #include "../defs.h"
 #include <iostream>
 
-#include "fplll/nr/nr_rand.inl"
+#include "nr_rand.inl"
 
-#include "fplll/nr/nr_Z.inl"
-#include "fplll/nr/nr_Z_d.inl"
-#include "fplll/nr/nr_Z_l.inl"
-#include "fplll/nr/nr_Z_mpz.inl"
-
-#include "fplll/nr/nr_FP.inl"
-#include "fplll/nr/nr_FP_d.inl"
-#include "fplll/nr/nr_FP_ld.inl"
+#include "nr_Z.inl"
+#include "nr_Z_d.inl"
+#include "nr_Z_l.inl"
+#include "nr_Z_mpz.inl"
+#include "nr_FP.inl"
+#include "nr_FP_d.inl"
+#include "nr_FP_ld.inl"
 
 #ifdef FPLLL_WITH_DPE
-#include "fplll/nr/nr_FP_dpe.inl"
+#include "nr_FP_dpe.inl"
 #endif
 
 #ifdef FPLLL_WITH_QD
-#include "fplll/nr/nr_FP_dd.inl"
-#include "fplll/nr/nr_FP_qd.inl"
+#include "nr_FP_dd.inl"
+#include "nr_FP_qd.inl"
 #endif
 
-#include "fplll/nr/nr_FP_mpfr.inl"
+#include "nr_FP_mpfr.inl"
 
-#include "fplll/nr/nr_FP_misc.inl"
-#include "fplll/nr/nr_Z_misc.inl"
+#include "nr_FP_misc.inl"
+#include "nr_Z_misc.inl"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/nr/nr.h
+++ b/fplll/nr/nr.h
@@ -9,13 +9,13 @@
 
 #include "nr_rand.inl"
 
+#include "nr_FP.inl"
+#include "nr_FP_d.inl"
+#include "nr_FP_ld.inl"
 #include "nr_Z.inl"
 #include "nr_Z_d.inl"
 #include "nr_Z_l.inl"
 #include "nr_Z_mpz.inl"
-#include "nr_FP.inl"
-#include "nr_FP_d.inl"
-#include "nr_FP_ld.inl"
 
 #ifdef FPLLL_WITH_DPE
 #include "nr_FP_dpe.inl"

--- a/fplll/nr/nr_Z_l.inl
+++ b/fplll/nr/nr_Z_l.inl
@@ -29,7 +29,7 @@ template <> inline void Z_NR<long>::get_mpz(mpz_t r) const { mpz_set_si(r, data)
 
 inline long compute_long_exponent(long data)
 {
-  unsigned long y = static_cast<unsigned long>(abs(data));
+  unsigned long y = static_cast<unsigned long>(std::abs(data));
   long e;
   for (e = 0; y; e++, y >>= 1)
   {

--- a/fplll/nr/numvect.h
+++ b/fplll/nr/numvect.h
@@ -16,7 +16,7 @@
 #ifndef FPLLL_NUMVECT_H
 #define FPLLL_NUMVECT_H
 
-#include "fplll/nr/nr.h"
+#include "nr.h"
 #include <vector>
 
 FPLLL_BEGIN_NAMESPACE

--- a/fplll/pruner/pruner.cpp
+++ b/fplll/pruner/pruner.cpp
@@ -14,9 +14,9 @@
   along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include "pruner.h"
-#include "ballvol.const"
-#include "factorial.const"
-#include "fplll.h"
+#include "../ballvol.const"
+#include "../factorial.const"
+#include "../fplll.h"
 
 // add components
 #include "pruner_cost.cpp"

--- a/fplll/pruner/pruner.h
+++ b/fplll/pruner/pruner.h
@@ -17,8 +17,8 @@
 #ifndef FPLLL_PRUNER_H
 #define FPLLL_PRUNER_H
 
-#include "fplll/defs.h"
-#include "fplll/lll.h"
+#include "../defs.h"
+#include "../lll.h"
 #include <vector>
 
 FPLLL_BEGIN_NAMESPACE

--- a/fplll/pruner/pruner_cost.cpp
+++ b/fplll/pruner/pruner_cost.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/pruner/pruner_optimize.cpp
+++ b/fplll/pruner/pruner_optimize.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/pruner/pruner_optimize_tc.cpp
+++ b/fplll/pruner/pruner_optimize_tc.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/pruner/pruner_optimize_tp.cpp
+++ b/fplll/pruner/pruner_optimize_tp.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/pruner/pruner_prob.cpp
+++ b/fplll/pruner/pruner_prob.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/pruner/pruner_util.cpp
+++ b/fplll/pruner/pruner_util.cpp
@@ -1,4 +1,4 @@
-#include "fplll.h"
+#include "../fplll.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/threadpool.cpp
+++ b/fplll/threadpool.cpp
@@ -13,7 +13,7 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include <fplll/threadpool.h>
+#include "threadpool.h"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/fplll/threadpool.h
+++ b/fplll/threadpool.h
@@ -16,8 +16,8 @@
 #ifndef FPLLL_THREADPOOL_H
 #define FPLLL_THREADPOOL_H
 
-#include <fplll/defs.h>
-#include <fplll/io/thread_pool.hpp>
+#include "defs.h"
+#include "io/thread_pool.hpp"
 
 FPLLL_BEGIN_NAMESPACE
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,83 @@
+enable_testing()
+set_directory_properties(PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${COVERAGE_ARTIFACTS}")
+
+# -I all ${prefix}/include/fplll headers
+include_directories(${CMAKE_INSTALL_FULL_INCLUDEDIR})
+add_compile_definitions(TESTDATADIR="${TOPSRCDIR}")
+
+add_executable(test_nr test_nr.cpp)
+target_link_libraries(test_nr PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestNR COMMAND ${CMAKE_BINARY_DIR}/test_nr)
+
+add_executable(test_lll EXCLUDE_FROM_ALL test_lll.cpp)
+target_link_libraries(test_lll PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestLLL COMMAND ${CMAKE_BINARY_DIR}/test_lll)
+
+add_executable(test_enum EXCLUDE_FROM_ALL test_enum.cpp)
+target_link_libraries(test_enum PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestENUM COMMAND ${CMAKE_BINARY_DIR}/test_enum)
+
+add_executable(test_svp EXCLUDE_FROM_ALL test_svp.cpp)
+target_link_libraries(test_svp PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestSVP COMMAND ${CMAKE_BINARY_DIR}/test_svp)
+
+add_executable(test_cvp EXCLUDE_FROM_ALL test_cvp.cpp)
+target_link_libraries(test_cvp PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestCVP COMMAND ${CMAKE_BINARY_DIR}/test_cvp)
+
+add_executable(test_bkz EXCLUDE_FROM_ALL test_bkz.cpp)
+target_link_libraries(test_bkz PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestBKZ COMMAND ${CMAKE_BINARY_DIR}/test_bkz)
+
+add_executable(test_pruner EXCLUDE_FROM_ALL test_pruner.cpp)
+target_link_libraries(test_pruner PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestPRUNER COMMAND ${CMAKE_BINARY_DIR}/test_pruner)
+
+add_executable(test_gso EXCLUDE_FROM_ALL test_gso.cpp)
+target_link_libraries(test_gso PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestGSO COMMAND ${CMAKE_BINARY_DIR}/test_gso)
+
+add_executable(test_lll_gram EXCLUDE_FROM_ALL test_lll_gram.cpp)
+target_link_libraries(test_lll_gram PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestLLL_GRAM COMMAND ${CMAKE_BINARY_DIR}/test_lll_gram)
+
+add_executable(test_hlll EXCLUDE_FROM_ALL test_hlll.cpp)
+target_link_libraries(test_hlll PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestHLLL COMMAND ${CMAKE_BINARY_DIR}/test_hlll)
+
+add_executable(test_svp_gram EXCLUDE_FROM_ALL test_svp_gram.cpp)
+target_link_libraries(test_svp_gram PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestSVP_GRAM COMMAND ${CMAKE_BINARY_DIR}/test_svp_gram)
+
+add_executable(test_bkz_gram EXCLUDE_FROM_ALL test_bkz_gram.cpp)
+target_link_libraries(test_bkz_gram PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestBKZ_GRAM COMMAND ${CMAKE_BINARY_DIR}/test_bkz_gram)
+
+add_executable(test_counter EXCLUDE_FROM_ALL test_counter.cpp)
+target_link_libraries(test_counter PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestCOUNTER COMMAND ${CMAKE_BINARY_DIR}/test_counter)
+
+add_executable(test_babai EXCLUDE_FROM_ALL test_babai.cpp)
+target_link_libraries(test_babai PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestBABAI COMMAND ${CMAKE_BINARY_DIR}/test_babai)
+
+add_executable(test_ceil EXCLUDE_FROM_ALL test_ceil.cpp)
+target_link_libraries(test_ceil PRIVATE ${FPLLL_LIBS})
+add_test(NAME TestCEIL COMMAND ${CMAKE_BINARY_DIR}/test_ceil)
+
+
+add_custom_target(build_tests
+  ALL DEPENDS test_nr test_lll test_enum
+  test_svp test_cvp test_bkz test_pruner test_gso
+  test_lll_gram test_hlll test_svp_gram test_bkz_gram
+  test_counter test_babai test_ceil
+)
+
+# Create a custom target to run the tests
+add_custom_target(run_tests
+    COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+    DEPENDS build_tests
+)
+
+# 'make test' also run 'ctest'
+add_custom_target(test DEPENDS run_tests)

--- a/tests/test_babai.cpp
+++ b/tests/test_babai.cpp
@@ -13,7 +13,7 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "fplll/fplll.h"
+#include <fplll/fplll.h>
 #include <vector>
 
 #include <cfloat>  // Needed for precision macros.

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -13,10 +13,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "io/json.hpp"
 #include <cstring>
-#include <fplll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include <fplll/io/json.hpp>
+#include "test_utils.h"
 
 using json = nlohmann::json;
 

--- a/tests/test_bkz.cpp
+++ b/tests/test_bkz.cpp
@@ -13,10 +13,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
 #include <fplll/io/json.hpp>
-#include "test_utils.h"
 
 using json = nlohmann::json;
 

--- a/tests/test_bkz_gram.cpp
+++ b/tests/test_bkz_gram.cpp
@@ -14,12 +14,12 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
 #include <fplll/gso_gram.h>
 #include <fplll/gso_interface.h>
 #include <fplll/io/json.hpp>
-#include "test_utils.h"
 
 using json = nlohmann::json;
 

--- a/tests/test_bkz_gram.cpp
+++ b/tests/test_bkz_gram.cpp
@@ -14,12 +14,12 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
-#include "io/json.hpp"
 #include <cstring>
-#include <fplll.h>
-#include <gso_gram.h>
-#include <gso_interface.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include <fplll/gso_gram.h>
+#include <fplll/gso_interface.h>
+#include <fplll/io/json.hpp>
+#include "test_utils.h"
 
 using json = nlohmann::json;
 

--- a/tests/test_ceil.cpp
+++ b/tests/test_ceil.cpp
@@ -1,4 +1,4 @@
-#include "fplll/fplll.h"
+#include <fplll/fplll.h>
 
 using namespace fplll;
 

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -14,8 +14,8 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_cvp.cpp
+++ b/tests/test_cvp.cpp
@@ -13,9 +13,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
-#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -13,9 +13,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
-#include "test_utils.h"
 
 using namespace fplll;
 

--- a/tests/test_enum.cpp
+++ b/tests/test_enum.cpp
@@ -15,7 +15,7 @@
 
 #include <cstring>
 #include <fplll/fplll.h>
-#include <test_utils.h>
+#include "test_utils.h"
 
 using namespace fplll;
 

--- a/tests/test_gso.cpp
+++ b/tests/test_gso.cpp
@@ -14,13 +14,13 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <gso.h>
-#include <gso_gram.h>
-#include <gso_interface.h>
-#include <householder.h>
-#include <nr/matrix.h>
+#include <fplll/gso.h>
+#include <fplll/gso_gram.h>
+#include <fplll/gso_interface.h>
+#include <fplll/householder.h>
+#include <fplll/nr/matrix.h>
 // #include <random>
-#include <test_utils.h>
+#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_hlll.cpp
+++ b/tests/test_hlll.cpp
@@ -14,9 +14,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
-#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_hlll.cpp
+++ b/tests/test_hlll.cpp
@@ -15,8 +15,8 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -13,9 +13,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
-#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll.cpp
+++ b/tests/test_lll.cpp
@@ -14,8 +14,8 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -14,13 +14,13 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
 #include <fplll/gso.h>
 #include <fplll/gso_gram.h>
 #include <fplll/gso_interface.h>
 #include <fplll/lll.h>
-#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_lll_gram.cpp
+++ b/tests/test_lll_gram.cpp
@@ -15,12 +15,12 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <gso.h>
-#include <gso_gram.h>
-#include <gso_interface.h>
-#include <lll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include <fplll/gso.h>
+#include <fplll/gso_gram.h>
+#include <fplll/gso_interface.h>
+#include <fplll/lll.h>
+#include "test_utils.h"
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_nr.cpp
+++ b/tests/test_nr.cpp
@@ -14,7 +14,7 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
+#include <fplll/fplll.h>
 
 using namespace std;
 using namespace fplll;

--- a/tests/test_pruner.cpp
+++ b/tests/test_pruner.cpp
@@ -14,7 +14,7 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
+#include <fplll/fplll.h>
 
 #ifdef FPLLL_WITH_QD
 #include <qd/dd_real.h>

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -14,9 +14,9 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
-#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_svp.cpp
+++ b/tests/test_svp.cpp
@@ -15,8 +15,8 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_svp_gram.cpp
+++ b/tests/test_svp_gram.cpp
@@ -15,10 +15,10 @@
    You should have received a copy of the GNU Lesser General Public License
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
+#include "test_utils.h"
 #include <cstring>
 #include <fplll/fplll.h>
 #include <fplll/gso_gram.h>
-#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_svp_gram.cpp
+++ b/tests/test_svp_gram.cpp
@@ -16,9 +16,9 @@
    along with fplll. If not, see <http://www.gnu.org/licenses/>. */
 
 #include <cstring>
-#include <fplll.h>
-#include <gso_gram.h>
-#include <test_utils.h>
+#include <fplll/fplll.h>
+#include <fplll/gso_gram.h>
+#include "test_utils.h"
 
 #ifndef TESTDATADIR
 #define TESTDATADIR ".."

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -1,7 +1,7 @@
 #ifndef TEST_UTILS_H
 #define TEST_UTILS_H 
 
-#include <fplll.h>
+#include <fplll/fplll.h>
 using namespace std;
 using namespace fplll;
 


### PR DESCRIPTION
As a follow-up of #528, this PR adds [6f2add8](https://github.com/fplll/fplll/tree/6f2add86af4afac174ec5cb5239aa1643a589e64) for the optional support for `cmake`.


the `cmake` build config is only my best effort, and not super well tested. I locally run, the artifacts are as close to the `automake` tool as possible. Hopefully this is just pure additional and completely optional to the developers to use it.  (added the "unofficial" warning in README)