### PR TITLE
Remove warning for >=C++20 compilers

### DIFF
--- a/fplll/nr/nr_FP.inl
+++ b/fplll/nr/nr_FP.inl
@@ -27,11 +27,11 @@ public:
   /**
    * Constructors.
    */
-  inline FP_NR<F>();
-  inline FP_NR<F>(const FP_NR<F> &f);
+  inline FP_NR();
+  inline FP_NR(const FP_NR<F> &f);
   inline ~FP_NR();
-  inline FP_NR<F>(const double d) : FP_NR<F>() { *this = d; };
-  inline FP_NR<F>(const char *s) : FP_NR<F>() { *this = s; };
+  inline FP_NR(const double d) : FP_NR() { *this = d; };
+  inline FP_NR(const char *s) : FP_NR() { *this = s; };
 
   /**
    * Returns the current precision for new FP_NR&lt;F&gt; objects.


### PR DESCRIPTION
There was the following warning when running `make`, when compiling the C++ code with a modern compiler (i.e. one that supports C++20 but still compiles with C++11):

	warning: template-id not allowed for constructor in C++20 [-Wtemplate-id-cdtor]
	note: remove the '< >'

More info, see: https://stackoverflow.com/questions/63513984/can-class-template-constructors-have-a-redundant-template-parameter-list-in-c2