### PR TITLE
call gcov differently

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Generate
         run: |
           make -j $JOBS check
-          cd fplll && gcov --object-directory .libs *.cpp && cd ..
+          cd fplll && gcov .libs/libfplll_la-*.o && cd ..
 
       - name: Push
         uses: codecov/codecov-action@v1


### PR DESCRIPTION
fixes #539

See https://stackoverflow.com/questions/28004184/libtool-prefixes-objects-but-gcov-requires-them-without-prefix