### PR TITLE
gso: Kahan-compensated subtraction in update_gso_row

### DIFF
--- a/fplll/gso_interface.cpp
+++ b/fplll/gso_interface.cpp
@@ -144,10 +144,27 @@ template <class ZT, class FT> bool MatGSOInterface<ZT, FT>::update_gso_row(int i
   {
     get_gram(ftmp1, i, j);
     FPLLL_DEBUG_CHECK(j == i || gso_valid_cols[j] >= j);
+    // Kahan-compensated subtraction loop computing
+    //   ftmp1 := <b_i, b_j> - sum_{k<j} mu(j,k) * r(i,k).
+    // The naive in-place form (ftmp1.sub(ftmp1, ftmp2)) suffers
+    // catastrophic cancellation in the diagonal case (j == i) when
+    // b_i is nearly in the span of {b*_k : k < i}, and can produce
+    // finite negative r(i,i) -- the squared GS norm -- on
+    // near-degenerate bases. Maintaining a Kahan compensation term
+    // captures the low-order bits lost on each subtraction and folds
+    // them back into the running sum at no cost in precision and at
+    // ~3x the inner-loop FP op count.
+    FT kahan_c, kahan_y, kahan_t;
+    kahan_c = 0.0;
     for (int k = 0; k < j; k++)
     {
       ftmp2.mul(mu(j, k), r(i, k));
-      ftmp1.sub(ftmp1, ftmp2);
+      // ftmp1 -= ftmp2, with running residual kahan_c.
+      kahan_y.add(ftmp2, kahan_c);    // y = ftmp2 + c
+      kahan_t.sub(ftmp1, kahan_y);    // t = ftmp1 - y
+      kahan_c.sub(ftmp1, kahan_t);    // c = ftmp1 - t  (approx y, off by lost bits)
+      kahan_c.sub(kahan_c, kahan_y);  // c = (ftmp1 - t) - y  (captured residual)
+      ftmp1 = kahan_t;
     }
     r(i, j) = ftmp1;
     if (i > j)


### PR DESCRIPTION
## Summary

Patch `MatGSOInterface::update_gso_row` to use Kahan-compensated subtraction when accumulating

```
ftmp1 := <b_i, b_j> - sum_{k<j} mu(j,k) * r(i,k)
```

The current naive in-place form (`ftmp1.sub(ftmp1, ftmp2)` per term) suffers catastrophic cancellation on the diagonal case (`j == i`) when `b_i` is nearly in the span of `{b*_k : k < i}`. The final `r(i,i)` (squared GS norm) can come out small or negative on near-degenerate bases, even when the true value is positive and well away from zero.

This is a known failure mode for naive recurrences over arbitrary-precision floats; it appears here at cryptographic-scale moduli where the partial sums grow large relative to the true difference.

## Reproducer

The SD-BKZ benchmark in [`sdbkz-benchmark`][zenodo] reliably triggers it at `n=100, beta=30, q=3329, 1000-bit MPFR`:

| condition       | bases with `get_r() < 0` on diagonal |
|-----------------|--------------------------------------|
| upstream (HEAD) | 38 / 100                             |
| this patch      |  0 /  55                             |

Per-seed evidence + reproducer scripts live at the Zenodo DOI; the identical patch is shipped there as `patches/fplll_gso_kahan.patch`.

## Fix

Maintain a Kahan compensation term over the inner loop and fold the residual back into the next subtraction. ~3× the inner-loop FP op count; no allocation; the change is local to `update_gso_row`.

## Validation

- `make check` passes 15/15 (`test_gso`, `test_lll`, `test_lll_gram`, `test_hlll`, `test_svp_gram`, `test_bkz`, `test_counter`, `test_babai`, `test_ceil`, `test_bkz_gram`, plus the integer / SVP / CVP suites).
- `make check-style` clean (formatted with clang-format 18, matching CI's `ubuntu-latest` apt version).
- Reproduced bit-identically on Intel 13900K and AMD 9950X3D under fpylll 0.6.4 (which vendors fplll 5.5.0) with this patch applied.

## Related

Same root mechanism as the cancellation discussion in [fpylll#272](https://github.com/fplll/fpylll/issues/272) (`Floating point exception for linearly dependent matrix`); this is a concrete reproducer + fix for the GSO path specifically.

Happy to split the diagonal-case detection into a separate guard if reviewers prefer that shape over the unconditional Kahan loop, or to add a dedicated near-degenerate test fixture if maintainers want one.

## Reference

Extended write-up, per-seed JSONs, cross-machine SHA-256 verification, and the disclosure timeline:

[https://doi.org/10.5281/zenodo.19686928][zenodo]
(repo `sdbkz-benchmark`, file `docs/disclosure/fplll_gso_kahan_findings.md`)

[zenodo]: https://doi.org/10.5281/zenodo.19686928